### PR TITLE
Recursive shell call bug

### DIFF
--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -56,7 +56,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
         shell_parser = subcmd.add_parser('test', help=self.HELP['test'])
         shell_parser.set_defaults(func=test_solve_api)
 
-    def parse_args(self, args=None, namespace=None):
+    def parse_solvebio_args(self, args=None, namespace=None):
         """
             Try to parse the args first, and then add the subparsers. We want
             to do this so that we can check to see if there are any unknown
@@ -181,7 +181,7 @@ def launch_ipython_shell(args):  # pylint: disable=unused-argument
 def main(argv=sys.argv[1:]):
     """ Main entry point for SolveBio CLI """
     parser = SolveArgumentParser()
-    args = parser.parse_args(argv)
+    args = parser.parse_solvebio_args(argv)
 
     if args.api_host:
         solvebio.api_host = args.api_host


### PR DESCRIPTION
When installing (not in a virtual environment), I have been getting:

```
RuntimeError: maximum recursion depth exceeded while calling a Python object
  File "/usr/local/lib/python2.7/dist-packages/solvebio-1.5.1-py2.7.egg/solvebio/cli/main.py", line 83, in parse_args
    return super(SolveArgumentParser, self).parse_args(args, namespace)
   File "/usr/lib/python2.7/dist-packages/argparse.py", line 1698, in parse_args
     args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python2.7/dist-packages/argparse.py", line 1730, in parse_known_args
     return self._parse_known_args(args, namespace)
  File "/usr/lib/python2.7/dist-packages/argparse.py", line 1935, in _parse_known_args
    stop_index = consume_positionals(start_index)
  File "/usr/lib/python2.7/dist-packages/argparse.py", line 1891, in consume_positionals
    take_action(action, args)
  File "/usr/lib/python2.7/dist-packages/argparse.py", line 1800, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python2.7/dist-packages/argparse.py", line 1117, in __call__
    parser.parse_args(arg_strings, namespace)
  File "/usr/local/lib/python2.7/dist-packages/solvebio-1.5.1-py2.7.egg/solvebio/cli/main.py", line 83, in parse_args
    return super(SolveArgumentParser, self).parse_args(args, namespace)
```

This addresses that, although I'm not totally sure what's going on or if this is the best fix.
