### PR TITLE
some error responses were not being parsed correctly; this simplifies

### DIFF
--- a/solvebio/errors.py
+++ b/solvebio/errors.py
@@ -36,21 +36,15 @@ class SolveError(Exception):
 
                     if 'detail' in self.json_body:
                         self.message = '%s' % self.json_body['detail']
+                        del self.json_body['detail']
 
                     if 'non_field_errors' in self.json_body:
-                        self.message = '%s.' % \
+                        self.message = '%s' % \
                             ', '.join(self.json_body['non_field_errors'])
+                        del self.json_body['non_field_errors']
 
-                    for k, v in self.json_body.items():
-                        if k not in ['detail', 'non_field_errors']:
-                            if isinstance(v, list):
-                                v = ', '.join(v)
-                            self.field_errors.append('%s (%s)' % (k, v))
-
-                    if self.field_errors:
-                        self.message += (' The following fields were missing '
-                                         'or invalid: %s' %
-                                         ', '.join(self.field_errors))
+                    if self.json_body:
+                        self.message += ' %s' % self.json_body
 
     def __str__(self):
         return self.message


### PR DESCRIPTION
error handling and just prints the error sent by the API