### PR TITLE
Add Annotator and Expression support

### DIFF
--- a/solvebio/__init__.py
+++ b/solvebio/__init__.py
@@ -137,6 +137,11 @@ def login(**kwargs):
 
     if not (api_key or access_token):
         print('No credentials found. Requests to SolveBio may fail.')
+    else:
+        from solvebio.client import client
+        # Update the client host and token
+        client.set_host()
+        client.set_token()
 
 
 __all__ = [

--- a/solvebio/__init__.py
+++ b/solvebio/__init__.py
@@ -92,6 +92,7 @@ _init_logging()
 from .version import VERSION  # noqa
 from .errors import SolveError
 from .query import Query, BatchQuery, Filter, GenomicFilter
+from .annotate import Annotator, Expression
 from .resource import (
     Dataset,
     DatasetCommit,
@@ -139,6 +140,8 @@ def login(**kwargs):
 
 
 __all__ = [
+    'Annotator',
+    'Expression',
     'BatchQuery',
     'Dataset',
     'DatasetField',

--- a/solvebio/annotate.py
+++ b/solvebio/annotate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from .client import client
+
+import itertools
+import logging
+logger = logging.getLogger('solvebio')
+
+
+class Annotator(object):
+    """
+    Runs the synchronous annotate endpoint against
+    batches of results from a query.
+    """
+    CHUNK_SIZE = 100
+
+    def __init__(self, fields, include_errors=False):
+        self.buffer = []
+        self.fields = fields
+        self.include_errors = include_errors
+
+    def annotate(self, records, chunk_size=CHUNK_SIZE):
+        """Annotate a set of records with stored fields.
+
+        Args:
+            records: A list or iterator (can be a Query object)
+            chunk_size: The number of records to annotate at once (max 500).
+
+        Returns:
+            A generator that yields one annotated record at a time.
+        """
+        it = iter(records)
+        while True:
+            chunk = tuple(itertools.islice(it, chunk_size))
+            if not chunk:
+                return
+
+            data = {
+                'records': chunk,
+                'fields': self.fields,
+                'include_errors': self.include_errors
+            }
+
+            for r in client.post('/v1/annotate', data)['results']:
+                yield r
+
+
+class Expression(object):
+    """Runs a single SolveBio expression."""
+
+    def __init__(self, expr):
+        self.expr = expr
+
+    def evaluate(self, data=None, data_type='string', is_list=False):
+        """Evaluates the expression with the provided context and format."""
+        payload = {
+            'data': data,
+            'expression': self.expr,
+            'data_type': data_type,
+            'is_list': is_list
+        }
+        res = client.post('/v1/evaluate', payload)
+        return res['result']
+
+    def __repr__(self):
+        return '<Expression "{0}">'.format(self.expr)

--- a/solvebio/annotate.py
+++ b/solvebio/annotate.py
@@ -15,10 +15,11 @@ class Annotator(object):
     """
     CHUNK_SIZE = 100
 
-    def __init__(self, fields, include_errors=False):
+    def __init__(self, fields, include_errors=False, **kwargs):
         self.buffer = []
         self.fields = fields
         self.include_errors = include_errors
+        self.limit = kwargs.get('limit')
 
     def annotate(self, records, chunk_size=CHUNK_SIZE):
         """Annotate a set of records with stored fields.
@@ -30,6 +31,7 @@ class Annotator(object):
         Returns:
             A generator that yields one annotated record at a time.
         """
+        count = 0
         it = iter(records)
         while True:
             chunk = tuple(itertools.islice(it, chunk_size))
@@ -44,6 +46,9 @@ class Annotator(object):
 
             for r in client.post('/v1/annotate', data)['results']:
                 yield r
+                count += 1
+                if self.limit and count == self.limit:
+                    return
 
 
 class Expression(object):

--- a/solvebio/cli/ipython.py
+++ b/solvebio/cli/ipython.py
@@ -52,16 +52,18 @@ def launch_ipython_shell(args):  # pylint: disable=unused-argument
     # Add common solvebio classes and methods our namespace here so that
     # inside the ipython shell users don't have run imports
     import solvebio  # noqa
+    from solvebio import Annotator  # noqa
     from solvebio import BatchQuery  # noqa
     from solvebio import Dataset  # noqa
     from solvebio import DatasetCommit  # noqa
+    from solvebio import DatasetExport  # noqa
     from solvebio import DatasetField  # noqa
     from solvebio import DatasetImport  # noqa
     from solvebio import DatasetMigration  # noqa
-    from solvebio import DatasetExport  # noqa
     from solvebio import DatasetTemplate  # noqa
     from solvebio import Depository  # noqa
     from solvebio import DepositoryVersion  # noqa
+    from solvebio import Expression  # noqa
     from solvebio import Filter  # noqa
     from solvebio import GenomicFilter  # noqa
     from solvebio import Manifest  # noqa

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -283,7 +283,7 @@ class Query(object):
         if self._page_size <= 0:
             raise Exception('\'page_size\' parameter must be > 0')
 
-    def _clone(self, filters=None):
+    def _clone(self, filters=None, limit=None):
         new = self.__class__(self._dataset_id,
                              query=self._query,
                              genome_build=self._genome_build,
@@ -299,7 +299,17 @@ class Query(object):
         if filters:
             new._filters += filters
 
+        if limit:
+            new._limit = limit
+
         return new
+
+    def limit(self, limit):
+        """
+        Returns a new Query instance with the new
+        limit values.
+        """
+        return self._clone(limit=limit)
 
     def filter(self, *filters, **kwargs):
         """

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -697,6 +697,8 @@ class Query(object):
         return migration
 
     def annotate(self, fields, **kwargs):
+        from solvebio.annotate import Annotator
+
         return Annotator(fields, **kwargs).annotate(self)
 
 
@@ -735,52 +737,3 @@ class BatchQuery(object):
         _params.update(**params)
         response = client.post('/v1/batch_query', _params)
         return response
-
-
-class Annotator(object):
-    """
-    Runs the synchronous annotate endpoint against
-    batches of results from a query.
-    """
-    CHUNK_SIZE = 100
-
-    def __init__(self, fields, include_errors=False):
-        self.buffer = []
-        self.fields = fields
-        self.include_errors = include_errors
-
-    def annotate(self, records):
-        """Annotate a set of records with stored fields.
-
-        Args:
-            records: A list or iterator (can be a Query object)
-
-        Returns:
-            A generator that yields one annotated record at a time.
-        """
-        # `records` can be a Query object.
-        self.buffer = []
-        for record in records:
-            self.buffer.append(record)
-            if len(self.buffer) == self.CHUNK_SIZE:
-                for record in self._execute():
-                    yield record
-
-        for record in self._execute():
-            yield record
-
-    def _execute(self):
-        if not self.buffer:
-            return []
-        elif not self.fields:
-            return self.buffer
-
-        data = {
-            'records': self.buffer,
-            'fields': self.fields,
-            'include_errors': self.include_errors
-        }
-
-        res = client.post('/v1/annotate', data)
-        self.buffer = []
-        return res['results']

--- a/solvebio/test/test_annotate.py
+++ b/solvebio/test/test_annotate.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import unittest
+
+from solvebio import Annotator
+from solvebio import Expression
+
+
+class TestAnnotator(unittest.TestCase):
+
+    def test_annotator(self):
+        fields = [{'name': 'test', 'expression': '"hello world"'}]
+        records = [{'i': i} for i in range(100)]
+        a = Annotator(fields)
+
+        for i, result in enumerate(a.annotate(records)):
+            self.assertEqual(
+                result, {'test': 'hello world', 'i': i})
+
+
+class TestExpression(unittest.TestCase):
+
+    def test_expression(self):
+        answer = Expression("1+1").evaluate(data_type="integer")
+        self.assertEqual(answer, 2)
+
+    def test_expression_with_context(self):
+        answer = Expression("record").evaluate(
+            data={'record': 123}, data_type="integer")
+        self.assertEqual(answer, 123)

--- a/solvebio/test/test_login.py
+++ b/solvebio/test/test_login.py
@@ -46,3 +46,15 @@ class TestLogin(unittest.TestCase):
             solvebio.api_host = 'https://some.fake.domain.foobar'
             self.assertEqual(auth.login('foo'), False,
                              "Invalid login")
+
+    def test_init_login(self):
+        from solvebio import login
+        from solvebio.client import client
+        _auth = client._auth
+
+        client._auth = None
+        login(api_key="TEST_KEY")
+        self.assertEqual(client._auth.token, "TEST_KEY")
+
+        # Reset the key
+        client._auth = _auth


### PR DESCRIPTION
Uses the annotate endpoint which can add fields to lists of records.

Related to #146 

Supports the following usage:

```python
import solvebio
from solvebio import Dataset
solvebio.login()

# Annotate pathogenic records in ClinVar with the number of CIViC records for the variant
query = Dataset("ClinVar/Variants")\
    .query(fields=["variant_sbid", "rs_id", "rcv_accession", "phenotype"])\
    .filter(clinical_significance="pathogenic")\

fields = [
    {
        "name": "civic_count",
        "data_type": "integer",
        "expression": """
            dataset_count(
                'CIViC/Variants',
                entities=[('variant', record.variant_sbid)]
            )
        """
    }
]

for record in query.annotate(fields):
    if record['civic_count'] > 0:
        print record
```

