### PR TITLE
added genotype support to VCF importer

### DIFF
--- a/solvebio/contrib/vcf_parser/vcf_parser.py
+++ b/solvebio/contrib/vcf_parser/vcf_parser.py
@@ -240,7 +240,25 @@ class ExpandingVCFParser(object):
         variant_sbid = _variant_sbid(allele=allele,
                                      **genomic_coordinates)
 
-        return {
+        # Prepare genotype data
+        hom_ref = []
+        het = []
+        hom_alt = []
+        geno_data = []
+        for call in row.samples:
+            curr_geno_data = {}
+            for geno_key, geno_value  in call.data._asdict().iteritems():
+              curr_geno_data[geno_key] = geno_value
+            curr_geno_data['sample_id'] = call.sample
+            geno_data.append(curr_geno_data)
+            if(curr_geno_data['GT'] == '0/0'):
+                hom_ref.append(call.sample)
+            if(curr_geno_data['GT'] == '0/1'):
+                het.append(call.sample)
+            if(curr_geno_data['GT'] == '1/1'):
+                hom_alt.append(call.sample)
+
+        result = {
             'genomic_coordinates': genomic_coordinates,
             'variant': variant_sbid,
             'allele': allele,
@@ -251,6 +269,17 @@ class ExpandingVCFParser(object):
             'qual': row.QUAL,
             'filter': row.FILTER
         }
+
+        if geno_data:
+          result['genotypes'] = geno_data
+          result['samples_by_genotype'] = {}
+          result['samples_by_genotype']['hom_ref'] = hom_ref
+          result['samples_by_genotype']['het'] = het
+          result['samples_by_genotype']['hom_alt'] = hom_alt
+
+        return result
+
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
meant for review, not necessarily merge as yet.

Note - multiallelic variants need to be split by genotype-aware procedure before upload, such as the one in Hail.
The ipython session script below shows how this could be accomplished using the updated VCF importer in this PR:
```
import solvebio
solvebio.login()
from hail import *
hc = HailContext()

vds = hc.import_vcf('myfile.vcf')

# Split mutli-allelic variants, if any are present, outputing new vcf file *.split.vcf
vds.split_multi().export_vcf("myfile.split.vcf")

from solvebio.contrib.vcf_parser.vcf_parser import ExpandingVCFParser

parser = ExpandingVCFParser(filename="myfile.split.vcf", genome_build='GRCh37')

f = open('data.json', 'w')
import json
for x in parser:
  f.write(json.dumps(x) + "\n")
f.close()

from solvebio import Upload
from solvebio import Dataset
from solvebio import DatasetImport
upload = Upload.create(path='data.json')
dataset = Dataset.get_or_create_by_full_name("justin:genotypes/1.0.0/test2July20_2017")

 imp = DatasetImport.create(
      dataset_id=dataset.id,
      upload_id=upload.id,
       title='My test6.json import',
        auto_approve=True)

```

for reference, to setup `PYTHONPATH` for SPARK and Hail to be used in ipython with solvebio as above:
```
wget  https://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz
tar -xvzf spark-2.1.0-bin-hadoop2.7.tgz
wget  https://storage.googleapis.com/hail-common/distributions/hail-0.1-latest-spark2.1.0.zip
unzip hail-0.1-latest-spark2.1.0.zip
export WORKING_DIR=$(pwd)
export SPARK_HOME=$WORKING_DIR/spark-2.1.0-bin-hadoop2.7
export HAIL_HOME=$WORKING_DIR/hail


export PYTHONPATH=$PYTHONPATH:$HAIL_HOME/python:$SPARK_HOME/python/lib/pyspark.zip:$SPARK_HOME/python/lib/py4j-0.10.4-src.zip

export SPARK_CLASSPATH=$HAIL_HOME/jars/hail-all-spark.jar

```
