### PR TITLE
add target_full_path kwarg to export shortcut

### DIFF
--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -682,7 +682,8 @@ class Query(object):
                      % self._response)
         return _params, self._response
 
-    def export(self, format='json', follow=True, limit=None):
+    def export(self, format='json', follow=True, limit=None,
+               target_full_path=None):
         from solvebio import DatasetExport
 
         params = self._build_query()
@@ -700,6 +701,7 @@ class Query(object):
             dataset_id=self._dataset_id,
             format=format,
             params=params,
+            target_full_path=target_full_path,
             client=self._client
         )
 


### PR DESCRIPTION
Supports this:

```
dataset.query().export(format='json', target_full_path='my_vault:/path/to/my/json_files')
```