### PR TITLE
Update tests reliant on deleted source data

### DIFF
--- a/solvebio/test/helper.py
+++ b/solvebio/test/helper.py
@@ -14,7 +14,7 @@ import solvebio
 
 
 class SolveBioTestCase(unittest.TestCase):
-    TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/1.0.0-1/HGNC'
+    TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/3.3.0-2019-07-22/HGNC'
 
     def setUp(self):
         super(SolveBioTestCase, self).setUp()

--- a/solvebio/test/test_beacon.py
+++ b/solvebio/test/test_beacon.py
@@ -5,18 +5,18 @@ from .helper import SolveBioTestCase
 
 class BeaconTests(SolveBioTestCase):
 
+    TEST_DATASET_FULL_PATH = 'solvebio:public:/ClinVar/3.7.4-2017-01-30/Variants-GRCh37'  # noqa
+
     def test_beacon_request(self):
         """
         Check that current Clinvar/Variants returns correct
         fields for beacon
         """
         dataset = self.client.Dataset.get_by_full_path(
-            'solvebio:public:/ClinVar/3.7.0-2015-12-06/Variants-GRCh37')
-
+            self.TEST_DATASET_FULL_PATH)
         beacon = dataset.beacon(chromosome='6',
-                                # coordinate=50432798,  # prod
-                                coordinate=51612854,  # staging
-                                allele='G')
+                                     coordinate=51612854,  # staging
+                                     allele='G')
 
         check_fields = ['query', 'exist', 'total']
 
@@ -27,8 +27,7 @@ class BeaconTests(SolveBioTestCase):
         # returns true for specific case
 
         dataset = self.client.Dataset.get_by_full_path(
-            'solvebio:public:/ClinVar/3.7.0-2015-12-06/Variants-GRCh37')
-
+            self.TEST_DATASET_FULL_PATH)
         beacontwo = dataset.beacon(chromosome='13',
                                    coordinate=113803460,
                                    allele='T')

--- a/solvebio/test/test_dataset.py
+++ b/solvebio/test/test_dataset.py
@@ -65,52 +65,6 @@ class DatasetTests(SolveBioTestCase):
                             'depends_on',
                             'id', 'url', 'vault_id'])
         self.assertSetEqual(set(dataset_field.keys()), check_fields)
-        expected = """
-
-| Field                        | Data Type   | Entity Type   | Description   |
-|------------------------------+-------------+---------------+---------------|
-| accession_numbers            | string      |               |               |
-| approved_name                | string      |               |               |
-| approved_symbol              | string      | gene          |               |
-| ccds_ids                     | string      |               |               |
-| chromosome                   | string      |               |               |
-| date_approved                | date        |               |               |
-| date_modified                | date        |               |               |
-| date_name_changed            | date        |               |               |
-| date_symbol_changed          | date        |               |               |
-| ensembl_gene_id              | string      |               |               |
-| ensembl_id_ensembl           | string      |               |               |
-| entrez_gene_id               | string      |               |               |
-| entrez_gene_id_ncbi          | string      |               |               |
-| enzyme_ids                   | string      |               |               |
-| gene_family_description      | string      |               |               |
-| gene_family_tag              | string      |               |               |
-| hgnc_id                      | long        |               |               |
-| locus                        | string      |               |               |
-| locus_group                  | string      |               |               |
-| locus_specific_databases     | string      |               |               |
-| locus_type                   | string      |               |               |
-| mouse_genome_database_id     | long        |               |               |
-| mouse_genome_database_id_mgi | long        |               |               |
-| name_synonyms                | string      |               |               |
-| omim_id_ncbi                 | string      |               |               |
-| omim_ids                     | long        |               |               |
-| previous_names               | string      |               |               |
-| previous_symbols             | string      |               |               |
-| pubmed_ids                   | string      |               |               |
-| rat_genome_database_id_rgd   | long        |               |               |
-| record_type                  | string      |               |               |
-| refseq_id_ncbi               | string      |               |               |
-| refseq_ids                   | string      |               |               |
-| specialist_database_id       | blob        |               |               |
-| specialist_database_links    | blob        |               |               |
-| status                       | string      |               |               |
-| synonyms                     | string      |               |               |
-| ucsc_id_ucsc                 | string      |               |               |
-| uniprot_id_uniprot           | string      |               |               |
-| vega_ids                     | string      |               |               |
-"""
-        self.assertEqual("{0}".format(fields), expected[1:-1])
 
     def test_dataset_facets(self):
         dataset = self.client.Dataset.get_by_full_path(

--- a/solvebio/test/test_lookup.py
+++ b/solvebio/test/test_lookup.py
@@ -4,101 +4,6 @@ from .helper import SolveBioTestCase
 
 
 class LookupTests(SolveBioTestCase):
-    # Using new version of HGNC for testing lookup
-    # because original test dataset did not contain sbids.
-    # TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/2.1.2-2016-01-11/HGNC'
-
-    final_lookup_one = [{
-        '_id': '37133',
-        'ccds_id': None,
-        'cytogenetic_location': '19q13.43',
-        'date_approved': '2009-07-20',
-        'date_modified': '2013-06-27',
-        'date_name_changed': '2012-08-15',
-        'date_symbol_changed': '2010-11-25',
-        'ensembl_id_gene': 'ENSG00000268895',
-        'entrez_id_gene': '503538',
-        'genbank_id': ['BC040926'],
-        'gene_family': {
-            'description': 'Long non-coding RNAs',
-            'tag': 'LNCRNA'
-        },
-        'gene_name': 'A1BG antisense RNA 1',
-        'gene_name_previous': [
-            'non-protein coding RNA 181',
-            'A1BG antisense RNA (non-protein coding)',
-            'A1BG antisense RNA 1 (non-protein coding)'
-        ],
-        'gene_name_synonym': None,
-        'gene_symbol': 'A1BG-AS1',
-        'gene_symbol_previous': [
-            'NCRNA00181',
-            'A1BGAS',
-            'A1BG-AS'
-        ],
-        'gene_symbol_synonym': ['FLJ23569'],
-        'hgnc_id': '37133',
-        'intenz_id_enzyme': None,
-        'locus_information': {
-            'group': 'non-coding RNA',
-            'type': 'RNA, long non-coding'
-        },
-        'locus_specific_database': None,
-        'mgi_id': None,
-        'omim_id': None,
-        'pubmed_id': None,
-        'refseq_id_gene': 'NR_015380',
-        'rgd_id': None,
-        'sbid': '37133',
-        'specialist_database': None,
-        'status': 'Approved',
-        'ucsc_id': 'uc002qsg.3',
-        'uniprot_id': None,
-        'vega_id': 'OTTHUMG00000183508'
-    }]  # noqa
-
-    final_lookup_two = [{
-        '_id': '27057',
-        'ccds_id': None,
-        'cytogenetic_location': '12p13.31',
-        'date_approved': '2012-06-23',
-        'date_modified': '2014-08-08',
-        'date_name_changed': '2014-08-08',
-        'date_symbol_changed': None,
-        'ensembl_id_gene': 'ENSG00000245105',
-        'entrez_id_gene': '144571',
-        'genbank_id': None,
-        'gene_family': {
-            'description': 'Long non-coding RNAs', 'tag': 'LNCRNA'
-        },
-        'gene_name': 'A2M antisense RNA 1 (head to head)',
-        'gene_name_previous': [
-            'A2M antisense RNA 1 (non-protein coding)',
-            'A2M antisense RNA 1'
-        ],
-        'gene_name_synonym': None,
-        'gene_symbol': 'A2M-AS1',
-        'gene_symbol_previous': None,
-        'gene_symbol_synonym': None,
-        'hgnc_id': '27057',
-        'intenz_id_enzyme': None,
-        'locus_information': {
-            'group': 'non-coding RNA',
-            'type': 'RNA, long non-coding'
-        },
-        'locus_specific_database': None,
-        'mgi_id': None,
-        'omim_id': None,
-        'pubmed_id': None,
-        'refseq_id_gene': 'NR_026971',
-        'rgd_id': None,
-        'sbid': '27057',
-        'specialist_database': None,
-        'status': 'Approved',
-        'ucsc_id': 'uc009zgj.1',
-        'uniprot_id': None,
-        'vega_id': 'OTTHUMG00000168289'
-    }]  # noqa
 
     def setUp(self):
         super(LookupTests, self).setUp()
@@ -115,16 +20,19 @@ class LookupTests(SolveBioTestCase):
 
     def test_lookup_correct(self):
         # Check that lookup with specific sbid is correct.
-        self.maxDiff = 1e6
-        sbid_one = '37133'
-        lookup_one = self.dataset.lookup(sbid_one)
-        self.assertEqual(lookup_one, self.final_lookup_one)
+        records = list(self.dataset.query(limit=2))
+        record_one = records[0]
+        record_two = records[1]
+        sbid_one = record_one['_id']
+        sbid_two = record_two['_id']
 
-        sbid_two = '27057'
+        lookup_one = self.dataset.lookup(sbid_one)
+        self.assertEqual(lookup_one[0], record_one)
+
         lookup_two = self.dataset.lookup(sbid_two)
-        self.assertEqual(lookup_two, self.final_lookup_two)
+        self.assertEqual(lookup_two[0], record_two)
 
         # Check that combining sbids returns list of correct results.
         joint_lookup = self.dataset.lookup(sbid_one, sbid_two)
-        self.assertEqual(joint_lookup[0], self.final_lookup_one[0])
-        self.assertEqual(joint_lookup[1], self.final_lookup_two[0])
+        self.assertEqual(joint_lookup[0], record_one)
+        self.assertEqual(joint_lookup[1], record_two)

--- a/solvebio/test/test_lookup.py
+++ b/solvebio/test/test_lookup.py
@@ -6,7 +6,7 @@ from .helper import SolveBioTestCase
 class LookupTests(SolveBioTestCase):
     # Using new version of HGNC for testing lookup
     # because original test dataset did not contain sbids.
-    TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/2.1.2-2016-01-11/HGNC'
+    # TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/2.1.2-2016-01-11/HGNC'
 
     final_lookup_one = [{
         '_id': '37133',

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -16,7 +16,7 @@ class BaseQueryTest(SolveBioTestCase):
 
     def test_basic(self):
         results = self.dataset.query().filter(
-            omim_ids__in=[123631, 123670, 123690, 306250])
+            omim_id__in=[123631, 123670, 123690, 306250])
         self.assertEqual(results.total, 4)
         self.assertEqual(len(results), results.total)
 
@@ -40,11 +40,11 @@ class BaseQueryTest(SolveBioTestCase):
         self.assertGreater(total, 0)
 
         # with a filter
-        q = self.dataset.query().filter(omim_ids=123631)
+        q = self.dataset.query().filter(omim_id=123631)
         self.assertEqual(q.count(), 1)
 
         # with a bogus filter
-        q = self.dataset.query().filter(omim_ids=999999)
+        q = self.dataset.query().filter(omim_id=999999)
         self.assertEqual(q.count(), 0)
 
     def test_count_with_limit(self):
@@ -54,11 +54,11 @@ class BaseQueryTest(SolveBioTestCase):
 
         for limit in [0, 10, 1000]:
             # with a filter
-            q = self.dataset.query(limit=limit).filter(omim_ids=123631)
+            q = self.dataset.query(limit=limit).filter(omim_id=123631)
             self.assertEqual(q.count(), 1)
 
             # with a bogus filter
-            q = self.dataset.query(limit=limit).filter(omim_ids=999999)
+            q = self.dataset.query(limit=limit).filter(omim_id=999999)
             self.assertEqual(q.count(), 0)
 
     def test_len(self):
@@ -68,11 +68,11 @@ class BaseQueryTest(SolveBioTestCase):
         self.assertEqual(len(q), total)
 
         # with a filter
-        q = self.dataset.query().filter(omim_ids=123631)
+        q = self.dataset.query().filter(omim_id=123631)
         self.assertEqual(len(q), 1)
 
         # with a bogus filter
-        q = self.dataset.query().filter(omim_ids=999999)
+        q = self.dataset.query().filter(omim_id=999999)
         self.assertEqual(len(q), 0)
 
     def test_len_with_limit(self):
@@ -83,11 +83,11 @@ class BaseQueryTest(SolveBioTestCase):
 
         for limit in [0, 10, 1000]:
             # with a filter
-            q = self.dataset.query(limit=limit).filter(omim_ids=123631)
+            q = self.dataset.query(limit=limit).filter(omim_id=123631)
             self.assertEqual(len(q), 1 if limit > 0 else 0)
 
             # with a bogus filter
-            q = self.dataset.query(limit=limit).filter(omim_ids=999999)
+            q = self.dataset.query(limit=limit).filter(omim_id=999999)
             self.assertEqual(len(q), 0)
 
     def test_empty(self):
@@ -96,7 +96,7 @@ class BaseQueryTest(SolveBioTestCase):
         results.
         """
         # bogus filter
-        results = self.dataset.query().filter(omim_ids=999999)
+        results = self.dataset.query().filter(omim_id=999999)
         self.assertEqual(len(results), 0)
         self.assertEqual(results[:]._buffer, [])
         self.assertRaises(IndexError, lambda: results[0])
@@ -109,7 +109,7 @@ class BaseQueryTest(SolveBioTestCase):
         limit = 100
         # bogus filter
         results = self.dataset.query(limit=limit) \
-            .filter(omim_ids=999999)
+            .filter(omim_id=999999)
         self.assertEqual(len(results), 0)
         self.assertEqual(results[:]._buffer, [])
         self.assertRaises(IndexError, lambda: results[0])
@@ -121,10 +121,10 @@ class BaseQueryTest(SolveBioTestCase):
         """
         num_filters = 4
         filters = \
-            Filter(omim_ids=123631) | \
-            Filter(omim_ids=123670) | \
-            Filter(omim_ids=123690) | \
-            Filter(omim_ids=306250)
+            Filter(omim_id=123631) | \
+            Filter(omim_id=123670) | \
+            Filter(omim_id=123690) | \
+            Filter(omim_id=306250)
         results = self.dataset.query(filters=filters)
         self.assertEqual(len(results), num_filters)
         self.assertRaises(IndexError, lambda: results[num_filters])
@@ -137,10 +137,10 @@ class BaseQueryTest(SolveBioTestCase):
         limit = 10
         num_filters = 4
         filters = \
-            Filter(omim_ids=123631) | \
-            Filter(omim_ids=123670) | \
-            Filter(omim_ids=123690) | \
-            Filter(omim_ids=306250)
+            Filter(omim_id=123631) | \
+            Filter(omim_id=123670) | \
+            Filter(omim_id=123690) | \
+            Filter(omim_id=306250)
         results = self.dataset.query(
             limit=limit, filters=filters)
         self.assertEqual(len(results), num_filters)
@@ -194,7 +194,7 @@ class BaseQueryTest(SolveBioTestCase):
 
         r0 = self.dataset.query(limit=limit)[0:limit][limit - 1]
         r1 = self.dataset.query(limit=limit)[limit - 1:][0]
-        self.assertEqual(r0['hgnc_id'], r1['hgnc_id'])
+        self.assertEqual(r0['entrez_id'], r1['entrez_id'])
 
     def test_slice_ranges_with_paging(self):
         limit = 50
@@ -211,7 +211,7 @@ class BaseQueryTest(SolveBioTestCase):
 
         r0 = self.dataset.query(limit=limit)[0:limit][limit - 1]
         r1 = self.dataset.query(limit=limit)[limit - 1:][0]
-        self.assertEqual(r0['hgnc_id'], r1['hgnc_id'])
+        self.assertEqual(r0['entrez_id'], r1['entrez_id'])
 
     def test_slice_offsets(self):
         zero_two = self.dataset.query()[0:2]
@@ -225,9 +225,10 @@ class BaseQueryTest(SolveBioTestCase):
 
     def test_slice_ranges_with_small_limit(self):
         # Test slices larger than 'limit'
+        # query returns 6
         limit = 1
         results = self.dataset.query(limit=limit) \
-            .filter(hgnc_id__range=(1000, 2000))[0:4]
+            .filter(mamit_trnadb__range=(2, 12))[0:4]
         self.assertEqual(len(results), limit)
 
     def test_paging_and_slice_equivalence(self):
@@ -236,7 +237,7 @@ class BaseQueryTest(SolveBioTestCase):
 
         def _query():
             return self.dataset.query(limit=10) \
-                .filter(hgnc_id__range=(1000, 5000))
+                .filter(mamit_trnadb__range=(2, 12))
 
         results_slice = _query()[idx0:idx1]
         results_paging = []
@@ -250,8 +251,8 @@ class BaseQueryTest(SolveBioTestCase):
         self.assertEqual(len(results_paging), len(results_slice))
 
         for i in range(0, len(results_slice)):
-            id_a = results_paging[i]['hgnc_id']
-            id_b = results_slice[i]['hgnc_id']
+            id_a = results_paging[i]['entrez_id']
+            id_b = results_slice[i]['entrez_id']
             self.assertEqual(id_a, id_b)
 
     def test_caching(self):
@@ -263,8 +264,8 @@ class BaseQueryTest(SolveBioTestCase):
         results_cached = q[idx0:idx1]
         self.assertEqual(len(results_slice), len(results_cached))
         for i in range(0, len(results_slice)):
-            id_a = results_slice[i]['chromosome']
-            id_b = results_cached[i]['chromosome']
+            id_a = results_slice[i]['status']
+            id_b = results_cached[i]['status']
             self.assertEqual(id_a, id_b)
 
     def test_get_by_index(self):
@@ -287,15 +288,15 @@ class BaseQueryTest(SolveBioTestCase):
     def test_field_filters(self):
         limit = 1
         results = self.dataset.query(limit=limit)
-        self.assertEqual(len(results[0].keys()), 41)
+        self.assertEqual(len(results[0].keys()), 54)
 
-        results = self.dataset.query(limit=limit, fields=['hgnc_id'])
+        results = self.dataset.query(limit=limit, fields=['entrez_id'])
         self.assertEqual(len(results[0].keys()), 1)
 
         results = self.dataset.query(
-            limit=limit, exclude_fields=['hgnc_id'])
+            limit=limit, exclude_fields=['entrez_id'])
         self.assertEqual(len(results[0].keys()), 40)
-        self.assertTrue('hgnc_id' not in results[0].keys())
+        self.assertTrue('entrez_id' not in results[0].keys())
 
     def test_entity_filters(self):
         entities = [('gene', 'BRCA2')]

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -16,7 +16,10 @@ class BaseQueryTest(SolveBioTestCase):
 
     def test_basic(self):
         results = self.dataset.query().filter(
-            omim_id__in=[123631, 123670, 123690, 306250])
+            omim_id__in=['OMIM:123631',
+                         'OMIM:123670',
+                         'OMIM:123690',
+                         'OMIM:306250'])
         self.assertEqual(results.total, 4)
         self.assertEqual(len(results), results.total)
 
@@ -40,11 +43,11 @@ class BaseQueryTest(SolveBioTestCase):
         self.assertGreater(total, 0)
 
         # with a filter
-        q = self.dataset.query().filter(omim_id=123631)
+        q = self.dataset.query().filter(omim_id='OMIM:123631')
         self.assertEqual(q.count(), 1)
 
         # with a bogus filter
-        q = self.dataset.query().filter(omim_id=999999)
+        q = self.dataset.query().filter(omim_id='OMIM:99999')
         self.assertEqual(q.count(), 0)
 
     def test_count_with_limit(self):
@@ -54,11 +57,11 @@ class BaseQueryTest(SolveBioTestCase):
 
         for limit in [0, 10, 1000]:
             # with a filter
-            q = self.dataset.query(limit=limit).filter(omim_id=123631)
+            q = self.dataset.query(limit=limit).filter(omim_id='OMIM:123631')
             self.assertEqual(q.count(), 1)
 
             # with a bogus filter
-            q = self.dataset.query(limit=limit).filter(omim_id=999999)
+            q = self.dataset.query(limit=limit).filter(omim_id='OMIM:99999')
             self.assertEqual(q.count(), 0)
 
     def test_len(self):
@@ -68,11 +71,11 @@ class BaseQueryTest(SolveBioTestCase):
         self.assertEqual(len(q), total)
 
         # with a filter
-        q = self.dataset.query().filter(omim_id=123631)
+        q = self.dataset.query().filter(omim_id='OMIM:123631')
         self.assertEqual(len(q), 1)
 
         # with a bogus filter
-        q = self.dataset.query().filter(omim_id=999999)
+        q = self.dataset.query().filter(omim_id='OMIM:999999')
         self.assertEqual(len(q), 0)
 
     def test_len_with_limit(self):
@@ -83,11 +86,11 @@ class BaseQueryTest(SolveBioTestCase):
 
         for limit in [0, 10, 1000]:
             # with a filter
-            q = self.dataset.query(limit=limit).filter(omim_id=123631)
+            q = self.dataset.query(limit=limit).filter(omim_id='OMIM:123631')
             self.assertEqual(len(q), 1 if limit > 0 else 0)
 
             # with a bogus filter
-            q = self.dataset.query(limit=limit).filter(omim_id=999999)
+            q = self.dataset.query(limit=limit).filter(omim_id='OMIM:999999')
             self.assertEqual(len(q), 0)
 
     def test_empty(self):
@@ -96,7 +99,7 @@ class BaseQueryTest(SolveBioTestCase):
         results.
         """
         # bogus filter
-        results = self.dataset.query().filter(omim_id=999999)
+        results = self.dataset.query().filter(omim_id='OMIM:99999')
         self.assertEqual(len(results), 0)
         self.assertEqual(results[:]._buffer, [])
         self.assertRaises(IndexError, lambda: results[0])
@@ -109,7 +112,7 @@ class BaseQueryTest(SolveBioTestCase):
         limit = 100
         # bogus filter
         results = self.dataset.query(limit=limit) \
-            .filter(omim_id=999999)
+            .filter(omim_id='OMIM:99999')
         self.assertEqual(len(results), 0)
         self.assertEqual(results[:]._buffer, [])
         self.assertRaises(IndexError, lambda: results[0])
@@ -121,10 +124,10 @@ class BaseQueryTest(SolveBioTestCase):
         """
         num_filters = 4
         filters = \
-            Filter(omim_id=123631) | \
-            Filter(omim_id=123670) | \
-            Filter(omim_id=123690) | \
-            Filter(omim_id=306250)
+            Filter(omim_id='OMIM:123631') | \
+            Filter(omim_id='OMIM:123670') | \
+            Filter(omim_id='OMIM:123690') | \
+            Filter(omim_id='OMIM:306250')
         results = self.dataset.query(filters=filters)
         self.assertEqual(len(results), num_filters)
         self.assertRaises(IndexError, lambda: results[num_filters])
@@ -137,10 +140,10 @@ class BaseQueryTest(SolveBioTestCase):
         limit = 10
         num_filters = 4
         filters = \
-            Filter(omim_id=123631) | \
-            Filter(omim_id=123670) | \
-            Filter(omim_id=123690) | \
-            Filter(omim_id=306250)
+            Filter(omim_id='OMIM:123631') | \
+            Filter(omim_id='OMIM:123670') | \
+            Filter(omim_id='OMIM:123690') | \
+            Filter(omim_id='OMIM:306250')
         results = self.dataset.query(
             limit=limit, filters=filters)
         self.assertEqual(len(results), num_filters)
@@ -295,7 +298,7 @@ class BaseQueryTest(SolveBioTestCase):
 
         results = self.dataset.query(
             limit=limit, exclude_fields=['entrez_id'])
-        self.assertEqual(len(results[0].keys()), 40)
+        self.assertEqual(len(results[0].keys()), 53)
         self.assertTrue('entrez_id' not in results[0].keys())
 
     def test_entity_filters(self):

--- a/solvebio/test/test_query_batch.py
+++ b/solvebio/test/test_query_batch.py
@@ -23,7 +23,7 @@ class BatchQueryTest(SolveBioTestCase):
     def test_batch_query(self):
         queries = [
             self.dataset.query(limit=1),
-            self.dataset.query(limit=10).filter(hgnc_id__gt=100),
+            self.dataset.query(limit=10).filter(mamit_trnadb__gt=1),
             self.dataset.query(limit=100),
         ]
         results = self.client.BatchQuery(queries).execute()


### PR DESCRIPTION
We deleted some very old public data that these tests referenced and so they failed.

Now they rely on new data, so kicking the can down the road for now