### PR TITLE
retry on more status codes, raise error when upload unsuccessful

### DIFF
--- a/solvebio/errors.py
+++ b/solvebio/errors.py
@@ -7,6 +7,10 @@ class NotFoundError(Exception):
     pass
 
 
+class FileUploadError(Exception):
+    pass
+
+
 class SolveError(Exception):
     """Exceptions tailored to the kinds of errors from a SolveBio API
     request"""


### PR DESCRIPTION
Will retry on more status codes from amazon (recently saw a 400) and will also now raise an error when upload is unsuccessful, which is the desired behavior of the pipelines.