### PR TITLE
Upload CLI changes, Tag CLI, vault object shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v2.8.9](https://github.com/solvebio/solvebio-python/tree/v2.8.9) (2019-09-19)
+[Full Changelog](https://github.com/solvebio/solvebio-python/compare/v2.8.8...v2.8.9)
+
+**Merged pull requests:**
+
+- Fix issue with activity pagination [\#311](https://github.com/solvebio/solvebio-python/pull/311) ([davecap](https://github.com/davecap))
+- add target\_full\_path kwarg to export shortcut [\#310](https://github.com/solvebio/solvebio-python/pull/310) ([jsh2134](https://github.com/jsh2134))
+
 ## [v2.8.8](https://github.com/solvebio/solvebio-python/tree/v2.8.8) (2019-09-12)
 [Full Changelog](https://github.com/solvebio/solvebio-python/compare/v2.8.7...v2.8.8)
 
@@ -694,13 +702,13 @@
 [Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.9...v1.7.10)
 
 ## [1.7.9](https://github.com/solvebio/solvebio-python/tree/1.7.9) (2015-02-18)
-[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.8...1.7.9)
-
-## [1.7.8](https://github.com/solvebio/solvebio-python/tree/1.7.8) (2015-02-04)
-[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.7...1.7.8)
+[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.7...1.7.9)
 
 ## [1.7.7](https://github.com/solvebio/solvebio-python/tree/1.7.7) (2015-02-04)
-[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.6...1.7.7)
+[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.8...1.7.7)
+
+## [1.7.8](https://github.com/solvebio/solvebio-python/tree/1.7.8) (2015-02-04)
+[Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.6...1.7.8)
 
 ## [1.7.6](https://github.com/solvebio/solvebio-python/tree/1.7.6) (2015-01-29)
 [Full Changelog](https://github.com/solvebio/solvebio-python/compare/1.7.5...1.7.6)

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -261,7 +261,20 @@ def upload(args):
                     parent_folder = _create_folder(vault, folder_full_path)
                     parent_folder_path = parent_folder.full_path
 
+    # Exit if there are multiple local paths and the
+    # exclude paths are not absolute
     base_exclude_paths = args.exclude or []
+    if base_exclude_paths and len(args.local_path) > 1:
+        rel_exclude_paths = [p for p in base_exclude_paths
+                             if not os.path.isabs(p)]
+        local_path_parents = set([os.path.dirname(os.path.abspath(p))
+                                  for p in args.local_path])
+        if rel_exclude_paths and len(local_path_parents) > 1:
+            sys.exit('Exiting. Cannot apply the --exclude relative paths when '
+                     'multiple upload paths with different parent directories '
+                     'are specified. Make --exclude paths absolute or run '
+                     'upload paths one at a time.')
+
     for local_path in args.local_path:
 
         # Expand local path and strip trailing slash

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -114,8 +114,14 @@ def _upload_folder(domain, vault, base_remote_path, base_local_path,
                 continue
 
             try:
-                Object.get_by_full_path(
-                    os.path.join(remote_folder_full_path, f))
+                full_path = os.path.join(remote_folder_full_path, f)
+                obj = Object.get_by_full_path(full_path)
+                if obj.is_file:
+                    print('Notice: File already exists at {}'
+                          .format(full_path))
+                else:
+                    print('WARNING: A {} currently exists at {}'
+                          .format(obj.object_type, full_path))
             except NotFoundError:
                 remote_parent = Object.get_by_full_path(
                     remote_folder_full_path, assert_type='folder')

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -7,6 +7,7 @@ import re
 import sys
 import gzip
 import json
+import fnmatch
 
 import solvebio
 
@@ -56,12 +57,9 @@ def should_exclude(path, exclude_paths):
     if not exclude_paths:
         return False
 
-    if path in exclude_paths:
-        print("WARNING: Excluding path {} (via --exclude)".format(path))
-        return True
-
     for exclude_path in exclude_paths:
-        if path.startswith(exclude_path):
+        print(path, exclude_path)
+        if fnmatch.fnmatch(path, exclude_path):
             print("WARNING: Excluding path {} (via --exclude)".format(path))
             return True
 

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -126,28 +126,17 @@ def _upload_folder(domain, vault, base_remote_path, base_local_path,
         # Upload the files that do not yet exist on the remote
         for f in files:
             local_file_path = os.path.join(abs_local_parent_path, f)
-            if should_exclude(local_file_path, exclude_paths,
-                              dry_run=dry_run):
+            if should_exclude(local_file_path, exclude_paths, dry_run=dry_run):
                 continue
 
-            try:
-                full_path = os.path.join(remote_folder_full_path, f)
-                obj = Object.get_by_full_path(full_path)
-                if obj.is_file:
-                    print('Notice: File already exists at {}'
-                          .format(full_path))
-                else:
-                    print('WARNING: A {} currently exists at {}'
-                          .format(obj.object_type, full_path))
-            except NotFoundError:
-                if dry_run:
-                    print('[Dry Run] Uploading {} to {}'
-                          .format(local_file_path, remote_folder_full_path))
-                else:
-                    remote_parent = Object.get_by_full_path(
-                        remote_folder_full_path, assert_type='folder')
-                    Object.upload_file(local_file_path, remote_parent.path,
-                                       vault.full_path)
+            if dry_run:
+                print('[Dry Run] Uploading {} to {}'
+                      .format(local_file_path, remote_folder_full_path))
+            else:
+                remote_parent = Object.get_by_full_path(
+                    remote_folder_full_path, assert_type='folder')
+                Object.upload_file(local_file_path, remote_parent.path,
+                                   vault.full_path)
 
 
 def create_dataset(args):
@@ -293,18 +282,12 @@ def upload(args):
                            local_name, exclude_paths=exclude_paths,
                            dry_run=args.dry_run)
         else:
-            # Upload if file does not exist
-            try:
-                full_path = os.path.join(path_dict['full_path'], local_name)
-                Object.get_by_full_path(full_path)
-                print("Notice: Object already exists: {}".format(full_path))
-            except NotFoundError:
-                if args.dry_run:
-                    print('[Dry Run] Uploading {} to {}'
-                          .format(local_path, path_dict['path']))
-                else:
-                    Object.upload_file(local_path, path_dict['path'],
-                                       vault.full_path)
+            if args.dry_run:
+                print('[Dry Run] Uploading {} to {}'
+                      .format(local_path, path_dict['path']))
+            else:
+                Object.upload_file(local_path, path_dict['path'],
+                                   vault.full_path)
 
 
 def import_file(args):

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -7,7 +7,7 @@ import re
 import sys
 import gzip
 import json
-import fnmatch
+from fnmatch import fnmatch
 
 import solvebio
 
@@ -58,9 +58,18 @@ def should_exclude(path, exclude_paths):
         return False
 
     for exclude_path in exclude_paths:
-        print(path, exclude_path)
-        if fnmatch.fnmatch(path, exclude_path):
-            print("WARNING: Excluding path {} (via --exclude)".format(path))
+
+        if fnmatch(path, exclude_path):
+            print("WARNING: Excluding path {} (via --exclude {})"
+                  .format(path, exclude_path))
+            return True
+
+        # An exclude path may be a directory, strip trailing slash and add /*
+        # if not already there.
+        if not exclude_path.endswith('/*') and \
+                fnmatch(path, exclude_path.rstrip('/') + '/*'):
+            print("WARNING: Excluding path {} (via --exclude {})"
+                  .format(path, exclude_path.rstrip('/') + '/*'))
             return True
 
     return False

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -370,23 +370,10 @@ def tag(args):
 
     objects = []
     for full_path in args.full_path:
-        vault_full_path = None
-        if not args.recursive:
-            # API will determine depth based
-            # on number of "/" in the glob
-            glob = full_path
-        else:
-            # Search recursively. Assumes global
-            # search if no vault found
-            parts = full_path.split('/', 1)
-            if len(parts) > 1:
-                vault_full_path, glob = parts
-            else:
-                glob = parts[0]
-
+        # API will determine depth based on number of "/" in the glob
+        # Add */** to match in any vault (recursive)
         objects.extend(list(Object.all(
-            glob=glob, vault_full_path=vault_full_path,
-            permission='write', limit=1000)))
+            glob=full_path, permission='write', limit=1000)))
 
     seen_vaults = {}
     taggable_objects = []

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -377,11 +377,7 @@ def tag(args):
     ]
 
     # Validate exclusion paths
-    exclusions = [
-        Object.validate_full_path(exclude_path)[0]
-        for exclude_path in args.exclude or []
-    ]
-
+    exclusions = args.exclude or []
     for object_ in validated_objects:
 
         if should_exclude(object_.full_path, exclusions,

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -221,9 +221,8 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 {
                     'flags': 'full_path',
                     'help': 'The full path of the files, '
-                    'folders or datasets to apply the tag updates.'
-                    'The value will be evaluated as regex if --regex '
-                    'flag enabled.',
+                    'folders or datasets to apply the tag updates. '
+                    'Unix shell-style wildcards are supported.',
                     'nargs': '+'
                 },
                 {
@@ -236,26 +235,20 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'required': True
                 },
                 {
+                    'flags': '--remove',
+                    'help': 'Will remove tags instead of adding them.',
+                    'action': 'store_true'
+                },
+                {
                     'flags': '--exclude',
                     'help': 'Paths to files or folder to be excluded from '
                     'tagging. Unix shell-style wildcards are supported.',
                     'action': 'append'
                 },
                 {
-                    'flags': '--regex',
-                    'help': 'Interprets full_path values as regular '
-                    'expressions',
-                    'action': 'store_true'
-                },
-                {
                     'flags': '--recursive',
                     'help': 'Will recursively apply tag updates to all '
                     'objects within the folders specified.',
-                    'action': 'store_true'
-                },
-                {
-                    'flags': '--remove',
-                    'help': 'Will remove tags instead of adding them.',
                     'action': 'store_true'
                 },
                 {

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -222,7 +222,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'flags': 'full_path',
                     'help': 'The full path of the files, '
                     'folders or datasets to apply the tag updates. '
-                    'Unix shell-style wildcards are supported. '
+                    'Unix shell-style wildcards are supported. ',
                     'nargs': '+'
                 },
                 {

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -198,7 +198,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'flags': '--exclude',
                     'help': 'Paths to files or folder to be excluded from '
                     'upload. Unix shell-style wildcards are supported.',
-                    'nargs': '+'
+                    'action': 'append'
                 },
                 {
                     'flags': '--dry-run',
@@ -229,15 +229,15 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'help': 'A tag to be added to an objects. '
                     'Files, folders and datasets can be tagged. '
                     'Tags are case insensitive strings. Example tags: '
-                    'GRCh38 Tissue "Foundation Medicine" new-tag',
-                    'nargs': '+',
+                    '--tag GRCh38 --tag Tissue --tag "Foundation Medicine"',
+                    'action': 'append',
                     'required': True
                 },
                 {
                     'flags': '--exclude',
                     'help': 'Paths to files or folder to be excluded from '
                     'tagging. Unix shell-style wildcards are supported.',
-                    'nargs': '+'
+                    'action': 'append'
                 },
                 {
                     'flags': '--recursive',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -196,7 +196,8 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 },
                 {
                     'flags': '--exclude',
-                    'help': 'File or folder paths to be excluded from upload.',
+                    'help': 'Paths to files or folder to be excluded from '
+                    'upload. Unix shell-style wildcards are supported.',
                     'nargs': '+'
                 },
                 {
@@ -228,7 +229,8 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 },
                 {
                     'flags': '--exclude',
-                    'help': 'File or folder paths to be excluded from upload.',
+                    'help': 'Paths to files or folder to be excluded from '
+                    'tagging. Unix shell-style wildcards are supported.',
                     'nargs': '+'
                 },
                 {

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -195,6 +195,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'nargs': '+'
                 },
                 {
+                    'flags': '--exclude',
+                    'help': 'File or folder paths to be excluded from upload.',
+                    'nargs': '+'
+                },
+                {
                     'flags': '-p',
                     'help': 'Creates --full-path location if it does '
                     'not exist. NOTE: This will not create new vaults.',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -240,6 +240,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'action': 'append'
                 },
                 {
+                    'flags': '--regex',
+                    'help': 'Interprets full_paths as regular expressions',
+                    'action': 'store_true'
+                },
+                {
                     'flags': '--recursive',
                     'help': 'Will recursively tag all objects within the '
                     'folders specified.',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -189,10 +189,10 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'default': '~/'
                 },
                 {
-                    'flags': '--tags',
-                    'help': 'A list of tags to be added to all objects. '
-                    'Example: " --tags grch38 tissue dnaseq "',
-                    'nargs': '+'
+                    'flags': '-p',
+                    'help': 'Creates --full-path location if it does '
+                    'not exist. NOTE: This will not create new vaults.',
+                    'action': 'store_true',
                 },
                 {
                     'flags': '--exclude',
@@ -200,10 +200,22 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'nargs': '+'
                 },
                 {
-                    'flags': '-p',
-                    'help': 'Creates --full-path location if it does '
-                    'not exist. NOTE: This will not create new vaults.',
-                    'action': 'store_true',
+                    'flags': '--tags',
+                    'help': 'A list of tags to be added to all objects. '
+                    'Example: " --tags grch38 tissue dnaseq "',
+                    'nargs': '+'
+                },
+                {
+                    'flags': '--tag-folders-only',
+                    'help': 'Will only apply tags to folders (tags files '
+                    'and folders by default). ',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-files-only',
+                    'help': 'Will only apply tags to files (tags files '
+                    'and folders by default). ',
+                    'action': 'store_true'
                 },
                 {
                     'name': 'local_path',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -222,7 +222,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'flags': 'full_path',
                     'help': 'The full path of the files, '
                     'folders or datasets to apply the tag updates. '
-                    'Unix shell-style wildcards are supported.',
+                    'Unix shell-style wildcards are supported. '
                     'nargs': '+'
                 },
                 {
@@ -244,12 +244,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'help': 'Paths to files or folder to be excluded from '
                     'tagging. Unix shell-style wildcards are supported.',
                     'action': 'append'
-                },
-                {
-                    'flags': '--recursive',
-                    'help': 'Will recursively apply tag updates to all '
-                    'objects within the folders specified.',
-                    'action': 'store_true'
                 },
                 {
                     'flags': '--tag-folders-only',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -216,17 +216,19 @@ class SolveArgumentParser(argparse.ArgumentParser):
         },
         'tag': {
             'func': data.tag,
-            'help': 'Apply tags to objects in SolveBio',
+            'help': 'Apply tags or remove tags on objects',
             'arguments': [
                 {
                     'flags': 'full_path',
                     'help': 'The full path of the files, '
-                    'folders or datasets to apply the tags.',
+                    'folders or datasets to apply the tag updates.'
+                    'The value will be evaluated as regex if --regex '
+                    'flag enabled.',
                     'nargs': '+'
                 },
                 {
                     'name': '--tag',
-                    'help': 'A tag to be added to an objects. '
+                    'help': 'A tag to be added/removed. '
                     'Files, folders and datasets can be tagged. '
                     'Tags are case insensitive strings. Example tags: '
                     '--tag GRCh38 --tag Tissue --tag "Foundation Medicine"',
@@ -241,13 +243,14 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 },
                 {
                     'flags': '--regex',
-                    'help': 'Interprets full_paths as regular expressions',
+                    'help': 'Interprets full_path values as regular '
+                    'expressions',
                     'action': 'store_true'
                 },
                 {
                     'flags': '--recursive',
-                    'help': 'Will recursively tag all objects within the '
-                    'folders specified.',
+                    'help': 'Will recursively apply tag updates to all '
+                    'objects within the folders specified.',
                     'action': 'store_true'
                 },
                 {
@@ -280,7 +283,8 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 },
                 {
                     'flags': '--no-input',
-                    'help': 'Runs the command without user input.',
+                    'help': 'Automatically accept changes (overrides '
+                    'user prompt)',
                     'action': 'store_true'
                 },
             ]

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -201,6 +201,12 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'nargs': '+'
                 },
                 {
+                    'flags': '--dry-run',
+                    'help': 'Dry run mode will not upload any files or '
+                    'create any folders.',
+                    'action': 'store_true'
+                },
+                {
                     'name': 'local_path',
                     'help': 'The path to the local file or directory '
                             'to upload',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -225,6 +225,48 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 }
             ]
         },
+        'tag': {
+            'func': data.tag,
+            'help': 'Apply tags to objects in SolveBio',
+            'arguments': [
+                {
+                    'name': 'tag',
+                    'help': 'A tag to be added to an objects. '
+                    'Files, folders, datasets and Vaults can be tagged. '
+                    'Tags are case insensitive strings. Example tags: '
+                    'GRCh38 Tissue "Foundation Medicine" new-tag',
+                    'nargs': '+'
+                },
+                {
+                    'flags': '--exclude',
+                    'help': 'File or folder paths to be excluded from upload.',
+                    'nargs': '+'
+                },
+                {
+                    'flags': '--recursive',
+                    'help': 'Will recursively tag all objects within the '
+                    'Vault or folder specified.',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--dry-run',
+                    'help': 'Dry run mode will not save tags.',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-folders-only',
+                    'help': 'Will only apply tags to folders (tags files '
+                    'and folders by default). ',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-files-only',
+                    'help': 'Will only apply tags to files (tags files '
+                    'and folders by default). ',
+                    'action': 'store_true'
+                }
+            ]
+        },
     }
 
     def __init__(self, *args, **kwargs):

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -189,7 +189,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'default': '~/'
                 },
                 {
-                    'flags': '-p',
+                    'flags': '--create-full-path',
                     'help': 'Creates --full-path location if it does '
                     'not exist. NOTE: This will not create new vaults.',
                     'action': 'store_true',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -251,6 +251,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'action': 'store_true'
                 },
                 {
+                    'flags': '--remove',
+                    'help': 'Will remove tags instead of adding them.',
+                    'action': 'store_true'
+                },
+                {
                     'flags': '--tag-folders-only',
                     'help': 'Will only apply tags to folders (tags '
                     'all objects by default). ',
@@ -271,6 +276,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 {
                     'flags': '--dry-run',
                     'help': 'Dry run mode will not save tags.',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--no-input',
+                    'help': 'Runs the command without user input.',
                     'action': 'store_true'
                 },
             ]

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -183,23 +183,22 @@ class SolveArgumentParser(argparse.ArgumentParser):
             'arguments': [
                 {
                     'flags': '--full-path',
-                    'required': True,
                     'help': 'The full path where the files and folders should '
                     'be created, defaults to the root of your personal vault',
-                    'action': TildeFixStoreAction
+                    'action': TildeFixStoreAction,
+                    'default': '~/'
                 },
                 {
-                    'flags': '--vault',
-                    'help': 'The vault where the files will be uploaded. '
-                    'Defaults to your personal vault. '
-                    'Overrides the vault component of --full-path',
-                    'action': TildeFixStoreAction
+                    'flags': '--tags',
+                    'help': 'A list of tags to be added to all objects. '
+                    'Example: " --tags grch38 tissue dnaseq "',
+                    'nargs': '+'
                 },
                 {
-                    'flags': '--path',
-                    'help': 'The path (relative to a vault) '
-                    'where the files will be uploaded. '
-                    'Overrides the path component of --full-path'
+                    'flags': '-p',
+                    'help': 'Creates --full-path location if it does '
+                    'not exist. NOTE: This will not create new vaults.',
+                    'action': 'store_true',
                 },
                 {
                     'name': 'local_path',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -200,24 +200,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'nargs': '+'
                 },
                 {
-                    'flags': '--tags',
-                    'help': 'A list of tags to be added to all objects. '
-                    'Example: " --tags grch38 tissue dnaseq "',
-                    'nargs': '+'
-                },
-                {
-                    'flags': '--tag-folders-only',
-                    'help': 'Will only apply tags to folders (tags files '
-                    'and folders by default). ',
-                    'action': 'store_true'
-                },
-                {
-                    'flags': '--tag-files-only',
-                    'help': 'Will only apply tags to files (tags files '
-                    'and folders by default). ',
-                    'action': 'store_true'
-                },
-                {
                     'name': 'local_path',
                     'help': 'The path to the local file or directory '
                             'to upload',
@@ -230,12 +212,19 @@ class SolveArgumentParser(argparse.ArgumentParser):
             'help': 'Apply tags to objects in SolveBio',
             'arguments': [
                 {
-                    'name': 'tag',
+                    'flags': 'full_path',
+                    'help': 'The full path of the files, '
+                    'folders or datasets to apply the tags.',
+                    'nargs': '+'
+                },
+                {
+                    'name': '--tag',
                     'help': 'A tag to be added to an objects. '
-                    'Files, folders, datasets and Vaults can be tagged. '
+                    'Files, folders and datasets can be tagged. '
                     'Tags are case insensitive strings. Example tags: '
                     'GRCh38 Tissue "Foundation Medicine" new-tag',
-                    'nargs': '+'
+                    'nargs': '+',
+                    'required': True
                 },
                 {
                     'flags': '--exclude',
@@ -245,7 +234,25 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 {
                     'flags': '--recursive',
                     'help': 'Will recursively tag all objects within the '
-                    'Vault or folder specified.',
+                    'folders specified.',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-folders-only',
+                    'help': 'Will only apply tags to folders (tags '
+                    'all objects by default). ',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-files-only',
+                    'help': 'Will only apply tags to files (tags '
+                    'all objects by default). ',
+                    'action': 'store_true'
+                },
+                {
+                    'flags': '--tag-datasets-only',
+                    'help': 'Will only apply tags to datasets (tags '
+                    'all objects by default). ',
                     'action': 'store_true'
                 },
                 {
@@ -253,18 +260,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'help': 'Dry run mode will not save tags.',
                     'action': 'store_true'
                 },
-                {
-                    'flags': '--tag-folders-only',
-                    'help': 'Will only apply tags to folders (tags files '
-                    'and folders by default). ',
-                    'action': 'store_true'
-                },
-                {
-                    'flags': '--tag-files-only',
-                    'help': 'Will only apply tags to files (tags files '
-                    'and folders by default). ',
-                    'action': 'store_true'
-                }
             ]
         },
     }

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -129,9 +129,16 @@ class Object(CreateableAPIResource,
             object_path = object_path.rstrip('/')
 
         path_dict['path'] = object_path
-        # TODO: parent_path and filename
-        full_path = '{domain}:{vault}:{path}'.format(**path_dict)
-        path_dict['full_path'] = full_path
+        path_dict['full_path'] = '{domain}:{vault}:{path}'.format(**path_dict)
+
+        # Assumes no trailing slash, will be '' if is a vault root
+        path_dict['filename'] = os.path.basename(object_path)
+
+        # Will be / if parent is vault root
+        path_dict['parent_path'] = os.path.dirname(object_path)
+        path_dict['parent_full_path'] = '{vault_full_path}:{parent_path}' \
+            .format(**path_dict)
+
         return full_path, path_dict
 
     @classmethod
@@ -191,10 +198,7 @@ class Object(CreateableAPIResource,
                 assert_type='folder', client=_client)
             parent_object_id = parent_obj.id
 
-        description = kwargs.get(
-            'description',
-            'File uploaded via python client'
-        )
+        description = kwargs.get('description')
 
         # Create the file, and upload it to the Upload URL
         obj = Object.create(

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -62,6 +62,7 @@ class Object(CreateableAPIResource,
                 * vault_full_path: domain:vault
                 * path: the object path within the vault
                 * parent_path: the parent path to the object
+                * parent_full_path: the parent full path to the object
                 * filename: the object's filename (if any)
                 * full_path: the validated full path
 
@@ -139,7 +140,7 @@ class Object(CreateableAPIResource,
         path_dict['parent_full_path'] = '{vault_full_path}:{parent_path}' \
             .format(**path_dict)
 
-        return full_path, path_dict
+        return path_dict['full_path'], path_dict
 
     @classmethod
     def get_by_full_path(cls, full_path, **params):

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -206,6 +206,7 @@ class Object(CreateableAPIResource,
             mimetype=mimetype,
             size=size,
             description=description,
+            tags=kwargs.get('tags', []) or [],
             client=_client
         )
 

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -251,7 +251,7 @@ class Object(CreateableAPIResource,
     def _object_list_helper(self, **params):
         """Helper method to get objects within"""
 
-        if self.object_type != 'folder':
+        if not self.is_folder:
             raise SolveError(
                 "Only folders contain child objects. This is a {}"
                 .format(self.object_type))
@@ -283,7 +283,7 @@ class Object(CreateableAPIResource,
         """Shortcut to query the underlying Dataset object"""
         from solvebio import Dataset
 
-        if self.object_type != 'dataset':
+        if not self.is_dataset:
             raise SolveError(
                 "The query method can only be used by a dataset. Found a {}"
                 .format(self.object_type))
@@ -305,3 +305,15 @@ class Object(CreateableAPIResource,
         """ Returns the vault object """
         from . import Vault
         return Vault.retrieve(self['vault_id'], client=self._client)
+
+    @property
+    def is_dataset(self):
+        return self.object_type == 'dataset'
+
+    @property
+    def is_folder(self):
+        return self.object_type == 'folder'
+
+    @property
+    def is_file(self):
+        return self.object_type == 'file'

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -248,6 +248,50 @@ class Object(CreateableAPIResource,
 
         return obj
 
+    def _object_list_helper(self, **params):
+        """Helper method to get objects within"""
+
+        if self.object_type != 'folder':
+            raise SolveError(
+                "Only folders contain child objects. This is a {}"
+                .format(self.object_type))
+
+        params.update({
+            'vault_id': self.vault_id,
+            'parent_object_id': self.id
+        })
+
+        items = self.all(client=self._client, **params)
+        return items
+
+    def files(self, **params):
+        return self._object_list_helper(object_type='file', **params)
+
+    def folders(self, **params):
+        return self._object_list_helper(object_type='folder', **params)
+
+    def datasets(self, **params):
+        return self._object_list_helper(object_type='dataset', **params)
+
+    def objects(self, **params):
+        return self._object_list_helper(**params)
+
+    def ls(self, **params):
+        return self.objects(**params)
+
+    def query(self, query=None, **params):
+        """Shortcut to query the underlying Dataset object"""
+        from solvebio import Dataset
+
+        if self.object_type != 'dataset':
+            raise SolveError(
+                "The query method can only be used by a dataset. Found a {}"
+                .format(self.object_type))
+
+        # TODO cache _dataset object?
+        _dataset = Dataset.retrieve(id=self.dataset_id)
+        return _dataset.query(query=query, **params)
+
     @property
     def parent(self):
         """ Returns the parent object """

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -288,9 +288,7 @@ class Object(CreateableAPIResource,
                 "The query method can only be used by a dataset. Found a {}"
                 .format(self.object_type))
 
-        # TODO cache _dataset object?
-        _dataset = Dataset.retrieve(id=self.dataset_id)
-        return _dataset.query(query=query, **params)
+        return Dataset(self.dataset_id).query(query=query, **params)
 
     @property
     def parent(self):

--- a/solvebio/test/client_mocks.py
+++ b/solvebio/test/client_mocks.py
@@ -28,7 +28,7 @@ class Fake201Response(object):
     def _retrieve_helper(self, model_name, field_name, error_value,
                          *args, **kwargs):
         obj = self.create()
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             obj[k] = v
 
         return obj

--- a/solvebio/test/client_mocks.py
+++ b/solvebio/test/client_mocks.py
@@ -11,7 +11,7 @@ class Fake201Response(object):
     def __init__(self, data):
         self.object = {
             'id': 100,
-            'class_name': self.class_name,
+            'class_name': self.class_name
         }
 
     def json(self):
@@ -23,6 +23,14 @@ class Fake201Response(object):
     def retrieve(self, r_id, *args, **kwargs):
         obj = self.create()
         obj.id = r_id
+        return obj
+
+    def _retrieve_helper(self, model_name, field_name, error_value,
+                         *args, **kwargs):
+        obj = self.create()
+        for k, v in kwargs.iteritems():
+            obj[k] = v
+
         return obj
 
     def all(self, *args, **kwargs):
@@ -90,7 +98,8 @@ class FakeObjectResponse(Fake201Response):
             'upload_url': None,
             'size': None,
             'md5': None,
-            'filename': 'file.json.gz'
+            'filename': 'file.json.gz',
+            'object_type': 'folder'
         }
 
 
@@ -175,6 +184,11 @@ def fake_object_all(*args, **kwargs):
 
 def fake_object_create(*args, **kwargs):
     return FakeObjectResponse(kwargs).create()
+
+
+def fake_object_retrieve(*args, **kwargs):
+    return FakeObjectResponse(kwargs)._retrieve_helper(
+        'LogicalObject', *args, **kwargs)
 
 
 def fake_dataset_create(*args, **kwargs):

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-# from solvebio.resource import Vault
 
 from .helper import SolveBioTestCase
 

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -19,6 +19,22 @@ class ObjectTests(SolveBioTestCase):
         with self.assertRaises(Exception):
             self.client.Object.get_by_full_path('what/is/this')
 
+    def test_object_output(self):
+
+        case = 'acme:myVault/uploads_folder'
+        expected = 'acme:myVault:/uploads_folder'
+        p, path_dict = self.client.Object.validate_full_path(case)
+
+        self.assertEqual(p, expected)
+        self.assertEqual(path_dict['full_path'], expected)
+        self.assertEqual(path_dict['path'], '/uploads_folder')
+        self.assertEqual(path_dict['parent_path'], '/')
+        self.assertEqual(path_dict['parent_full_path'], 'acme:myVault:/')
+        self.assertEqual(path_dict['filename'], 'uploads_folder')
+        self.assertEqual(path_dict['domain'], 'acme')
+        self.assertEqual(path_dict['vault'], 'myVault')
+        self.assertEqual(path_dict['vault_full_path'], 'acme:myVault')
+
     def test_object_path_cases(self):
 
         user = self.client.User.retrieve()

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -207,7 +207,8 @@ class CLITests(SolveBioTestCase):
 
         # pass -p to create destination
         args = ['upload', '--full-path',
-                'solvebio:test_vault:/test-folder', '-p', file_]
+                'solvebio:test_vault:/test-folder',
+                '--create-full-path', file_]
         self._test_upload_command(args)
 
     def test_upload_directories(self):
@@ -224,5 +225,6 @@ class CLITests(SolveBioTestCase):
 
         # pass -p to create destination
         args = ['upload', '--full-path',
-                'solvebio:test_vault:/test-folder-upload', '-p', folder_]
+                'solvebio:test_vault:/test-folder-upload',
+                '--create-full-path', folder_]
         self._test_upload_command(args)

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -266,16 +266,14 @@ class CLITests(SolveBioTestCase):
         exclude = ['*file.json']
         self.assertFalse(should_exclude('~/test3/file.txt', exclude))
 
-        # TODO
-        # Should pasing a directory disqualify all
         exclude = ['~/']
-        self.assertFalse(should_exclude('~/test3/file.txt', exclude))
+        self.assertTrue(should_exclude('~/test3/file.txt', exclude))
 
         exclude = ['~/test3/']
-        self.assertFalse(should_exclude('~/test3/file.txt', exclude))
+        self.assertTrue(should_exclude('~/test3/file.txt', exclude))
 
         exclude = ['~/test3']
-        self.assertFalse(should_exclude('~/test3/file.txt', exclude))
+        self.assertTrue(should_exclude('~/test3/file.txt', exclude))
 
         exclude = ['~/*']
         self.assertTrue(should_exclude('~/test3/file.txt', exclude))
@@ -283,7 +281,6 @@ class CLITests(SolveBioTestCase):
         exclude = ['~/test3/*']
         self.assertTrue(should_exclude('~/test3/file.txt', exclude))
 
-        # Not a full path match
         exclude = ['file.txt']
         self.assertFalse(should_exclude('~/test3/file.txt', exclude))
 
@@ -306,7 +303,7 @@ class CLITests(SolveBioTestCase):
                                         exclude))
 
         exclude = ['*folder']
-        self.assertFalse(should_exclude('~/folder/2019-01-01/file.txt',
+        self.assertTrue(should_exclude('~/folder/2019-01-01/file.txt',
                                         exclude))
 
         exclude = ['*folder*']

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -107,12 +107,14 @@ class CLITests(SolveBioTestCase):
     @mock.patch('solvebio.resource.Object.all')
     @mock.patch('solvebio.resource.Dataset.create')
     @mock.patch('solvebio.resource.DatasetTemplate.retrieve')
-    def test_create_dataset_template_id(self, TmplRetrieve, DatasetCreate,
-                                        ObjectAll, VaultAll):
+    @mock.patch('solvebio.resource.DatasetTemplate.create')
+    def test_create_dataset_template_id(self, TmplCreate, TmplRetrieve,
+                                        DatasetCreate, ObjectAll, VaultAll):
         VaultAll.side_effect = fake_vault_all
         ObjectAll.side_effect = fake_object_all
         DatasetCreate.side_effect = fake_dataset_create
         TmplRetrieve.side_effect = fake_dataset_tmpl_retrieve
+        TmplCreate.side_effect = fake_dataset_tmpl_create
 
         # create template
         template_path = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
### `solvebio upload` command changes

- Removes `--path` and `--vault` in favor of `--full-path` (--closes #224)
- Adds `--create-full-path` to create the upload destination if it does not exist (--closes #241)
- Adds `--exclude` parameter to exclude a list of paths (supports unix style globs) from uploading
- Adds `--dry-run` mode to evaluate before running

```
$ solvebio upload --help
usage: solvebio upload [-h] [--version] [--api-host API_HOST]
                       [--api-key API_KEY] [--api-token API_TOKEN]
                       [--full-path FULL_PATH] [--create-full-path]
                       [--exclude EXCLUDE [EXCLUDE ...]] [--dry-run]
                       local_path [local_path ...]

positional arguments:
  local_path            The path to the local file or directory to upload

SolveBio Options:
  -h, --help            show this help message and exit
  --full-path FULL_PATH
                        The full path where the files and folders should be
                        created, defaults to the root of your personal vault
  --create-full-path    Creates --full-path location if it does not exist.
                        NOTE: This will not create new vaults.
  --exclude EXCLUDE [EXCLUDE ...]
                        Paths to files or folder to be excluded from upload.
                        Unix shell-style wildcards are supported.
  --dry-run             Dry run mode will not upload any files or create any
                        folders.
```
### `solvebio tag` command (NEW) 

Adds command to tag objects

```
$ solvebio tag --help
usage: solvebio tag [-h] [--version] [--api-host API_HOST] [--api-key API_KEY]
                    [--api-token API_TOKEN] --tag TAG [--remove]
                    [--exclude EXCLUDE] [--recursive] [--tag-folders-only]
                    [--tag-files-only] [--tag-datasets-only] [--dry-run]
                    [--no-input]
                    full_path [full_path ...]

positional arguments:
  full_path             The full path of the files, folders or datasets to
                        apply the tag updates. Unix shell-style wildcards are
                        supported.

SolveBio Options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --api-host API_HOST   Override the default SolveBio API host
  --api-key API_KEY     Manually provide a SolveBio API key
  --api-token API_TOKEN
                        Manually provide a SolveBio OAuth API token
  --tag TAG             A tag to be added/removed. Files, folders and datasets
                        can be tagged. Tags are case insensitive strings.
                        Example tags: --tag GRCh38 --tag Tissue --tag
                        "Foundation Medicine"
  --remove              Will remove tags instead of adding them.
  --exclude EXCLUDE     Paths to files or folder to be excluded from tagging.
                        Unix shell-style wildcards are supported.
  --recursive           Will recursively apply tag updates to all objects
                        within the folders specified.
  --tag-folders-only    Will only apply tags to folders (tags all objects by
                        default).
  --tag-files-only      Will only apply tags to files (tags all objects by
                        default).
  --tag-datasets-only   Will only apply tags to datasets (tags all objects by
                        default).
  --dry-run             Dry run mode will not save tags.
  --no-input            Automatically accept changes (overrides user prompt)
```

### Adds a shortcut to a Vault objects 
Add shortcuts to Object class for retrieving child objects. Can now do: 
```
folder.files()
folder.datasets()
folder.objects()
folder.ls()
````

Previously had to do:
```
folder.vault.files(parent_object_id=folder.id)
folder.vault.datasets(parent_object_id=folder.id)
etc.
```

this closes #249

### Adds recursive shortcut to get all objects within

```
folder.files(recursive=True)
folder.datasets(recursive=True)
folder.objects(recursive=True)
folder.ls(recursive=True)
````


### adds a shortcut to a Dataset object 
if object is a dataset object, you can now do: 
```
object.query()
```
previously the Dataset object had to be retrieved first
```
Dataset.retrieve(object.dataset_id).query()
```