### PR TITLE
Updates to "create-dataset" and "import" shortcut commands

### DIFF
--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -428,6 +428,8 @@ def import_file(args):
         print("Your import has been submitted, view details at: {0}"
               .format(mesh_url))
 
+    return dataset
+
 
 def should_tag_by_object_type(args, object_):
     """Returns True if object matches object type requirements"""

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -153,17 +153,7 @@ def create_dataset(args):
     NOTE: genome_build has been deprecated and is no longer used.
 
     """
-    # For backwards compatibility, the "full_path" argument
-    # can be a dataset filename, but only if vault and path
-    # are set. If vault/path are both provided and there
-    # are no forward-slashes in the "full_path", assume
-    # the user has provided a dataset filename.
-    if '/' not in args.full_path and args.vault and args.path:
-        full_path, path_dict = Object.validate_full_path(
-            '{0}:/{1}/{2}'.format(args.vault, args.path, args.full_path))
-    else:
-        full_path, path_dict = Object.validate_full_path(
-            args.full_path, vault=args.vault, path=args.path)
+    full_path, path_dict = Object.validate_full_path(args.full_path)
 
     # Accept a template_id or a template_file
     if args.template_id:
@@ -300,16 +290,13 @@ def import_file(args):
         * create_dataset
         * template_id
         * full_path
-        * vault (optional, overrides the vault in full_path)
-        * path (optional, overrides the path in full_path)
         * commit_mode
         * capacity
         * file (list)
         * follow (default: False)
 
     """
-    full_path, path_dict = Object.validate_full_path(
-        args.full_path, vault=args.vault, path=args.path)
+    full_path, path_dict = Object.validate_full_path(args.full_path)
 
     # Ensure the dataset exists. Create if necessary.
     if args.create_dataset:

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -147,11 +147,9 @@ def create_dataset(args):
         * template_id
         * template_file
         * capacity
+        * tag
         * create_vault
-        * [argument] dataset name or full path
-
-    NOTE: genome_build has been deprecated and is no longer used.
-
+        * full path
     """
     full_path, path_dict = Object.validate_full_path(args.full_path)
 
@@ -200,12 +198,15 @@ def create_dataset(args):
         # include template used to create
         description = 'Created with dataset template: {0}'.format(str(tpl.id))
 
+    # TODO should we fail here if dataset exists already?
     return solvebio.Dataset.get_or_create_by_full_path(
         full_path,
         capacity=args.capacity,
         entity_type=entity_type,
         fields=fields,
         description=description,
+        tags=args.tag or [],
+        # metadata=args.metadata or None,
         create_vault=args.create_vault,
     )
 

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -155,7 +155,7 @@ def create_dataset(args):
         * dry_run
     """
     if args.dry_run:
-        print("NOTE: Running create_dataset command in dry run mode")
+        print("NOTE: Running create-dataset command in dry run mode")
 
     full_path, path_dict = Object.validate_full_path(args.full_path)
 

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -64,6 +64,20 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'help': 'Create the dataset if it doesn\'t exist',
                 },
                 {
+                    'name': '--tag',
+                    'help': 'A tag to be added. '
+                    'Tags are case insensitive strings. Example tags: '
+                    '--tag GRCh38 --tag Tissue --tag "Foundation Medicine"',
+                    'action': 'append',
+                },
+                {
+                    'flags': '--capacity',
+                    'default': 'small',
+                    'help': 'Specifies the capacity of the created dataset: '
+                            'small (default, <100M records), '
+                            'medium (<500M), large (>=500M)'
+                },
+                {
                     'flags': '--create-vault',
                     'action': 'store_true',
                     'help': 'Create the vault if it doesn\'t exist',
@@ -77,13 +91,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'flags': '--template-file',
                     'help': 'A local template file to be used when '
                             'creating a new dataset (via --create-dataset)',
-                },
-                {
-                    'flags': '--capacity',
-                    'default': 'small',
-                    'help': 'Specifies the capacity of the created dataset: '
-                            'small (default, <100M records), '
-                            'medium (<500M), large (>=500M)'
                 },
                 {
                     'flags': '--follow',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -103,18 +103,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                             'Options are "append" (default) or "overwrite".'
                 },
                 {
-                    'flags': '--vault',
-                    'help': 'The vault containing the dataset. '
-                    'Defaults to your personal vault. '
-                    'Overrides the vault component of --full-path',
-                    'action': TildeFixStoreAction
-                },
-                {
-                    'flags': '--path',
-                    'help': 'The path to the dataset (relative to a vault). '
-                    'Overrides the path component of --full-path'
-                },
-                {
                     'name': 'full_path',
                     'help': 'The full path to the dataset in the format: '
                     '"domain:vault:/path/dataset". ',
@@ -154,25 +142,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                             'medium (<500M), large (>=500M)'
                 },
                 {
-                    'flags': '--vault',
-                    'help':
-                    'The vault containing the dataset. '
-                    'Overrides the vault component of the full path argument',
-                    'action': TildeFixStoreAction
-                },
-                {
-                    'flags': '--path',
-                    'help': 'The path to the dataset (relative to the vault). '
-                    'Overrides the path component of the full path argument'
-                },
-                {
                     'name': 'full_path',
                     'help': 'The full path to the dataset in the format: '
                     '"domain:vault:/path/dataset". '
                     'Defaults to your personal vault if no vault is provided. '
-                    'Defaults to the vault root if no path is provided. '
-                    'Override the vault with --vault '
-                    'and/or the path with --path',
+                    'Defaults to the vault root if no path is provided.',
                     'action': TildeFixStoreAction
                 },
             ]

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -140,8 +140,14 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'flags': '--remote-source',
                     'action': 'store_true',
                     'default': False,
-                    'help': 'Flag is file upload paths are remote full '
-                    'paths on SolveBio'
+                    'help': 'File paths are remote globs or full paths on '
+                    'the SolveBio file system.'
+                },
+                {
+                    'flags': '--dry-run',
+                    'help': 'Dry run mode will not create any datasets or '
+                    'import any files.',
+                    'action': 'store_true'
                 },
                 {
                     'name': 'full_path',
@@ -202,6 +208,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 {
                     'name': '--metadata-json-file',
                     'help': 'Metadata key value pairs in JSON format'
+                },
+                {
+                    'flags': '--dry-run',
+                    'help': 'Dry run mode will not create the dataset',
+                    'action': 'store_true'
                 },
                 {
                     'name': 'full_path',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -79,11 +79,6 @@ class SolveArgumentParser(argparse.ArgumentParser):
                             'creating a new dataset (via --create-dataset)',
                 },
                 {
-                    'flags': '--genome-build',
-                    'help': 'If the dataset template is genomic, provide a '
-                            'genome build for your data (i.e. GRCh37)'
-                },
-                {
                     'flags': '--capacity',
                     'default': 'small',
                     'help': 'Specifies the capacity of the created dataset: '
@@ -141,6 +136,18 @@ class SolveArgumentParser(argparse.ArgumentParser):
                             'small (default, <100M records), '
                             'medium (<500M), large (>=500M)'
                 },
+                {
+                    'name': '--tag',
+                    'help': 'A tag to be added. '
+                    'Tags are case insensitive strings. Example tags: '
+                    '--tag GRCh38 --tag Tissue --tag "Foundation Medicine"',
+                    'action': 'append',
+                },
+                # {
+                #     'name': '--metadata',
+                #     'help': 'Dataset metadata to be added. '
+                #     'Metadata should be ....'
+                # },
                 {
                     'name': 'full_path',
                     'help': 'The full path to the dataset in the format: '

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -137,6 +137,13 @@ class SolveArgumentParser(argparse.ArgumentParser):
                             '"upsert", or "delete"'
                 },
                 {
+                    'flags': '--remote-source',
+                    'action': 'store_true',
+                    'default': False,
+                    'help': 'Flag is file upload paths are remote full '
+                    'paths on SolveBio'
+                },
+                {
                     'name': 'full_path',
                     'help': 'The full path to the dataset in the format: '
                     '"domain:vault:/path/dataset". ',
@@ -144,7 +151,10 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 },
                 {
                     'name': 'file',
-                    'help': 'One or more local files to import',
+                    'help': 'One or more files to import. Can be local files, '
+                    'folders, globs or remote URLs. Pass --remote-source in '
+                    'order to list remote full_paths or path globs on the '
+                    'SolveBio file system.',
                     'nargs': '+'
                 },
             ]

--- a/solvebio/resource/manifest.py
+++ b/solvebio/resource/manifest.py
@@ -52,13 +52,13 @@ class Manifest(object):
         All files are uploaded to SolveBio. The Upload
         object is used to fill the manifest.
         """
-        def _is_url(path):
+        def _is_supported_url(path):
             p = urlparse(path)
-            return bool(p.scheme)
+            return bool(p.scheme) and p.scheme in ['https', 'http']
 
         for path in args:
             path = os.path.expanduser(path)
-            if _is_url(path):
+            if _is_supported_url(path):
                 self.add_url(path)
             elif os.path.isfile(path):
                 self.add_file(path)
@@ -71,6 +71,7 @@ class Manifest(object):
             else:
                 raise ValueError(
                     'Path: "{0}" is not a valid format or does not exist. '
-                    'Manifest paths must be files, directories, or URLs.'
+                    'Manifest paths must be local files, directories, blobs '
+                    'or URLs with http:// or https://.'
                     .format(path)
                 )

--- a/solvebio/test/client_mocks.py
+++ b/solvebio/test/client_mocks.py
@@ -111,15 +111,27 @@ class FakeDatasetResponse(Fake201Response):
         self.object = {
             'class_name': self.class_name,
             'vault_id': None,
+            'vault_name': None,
             'id': 100,
             'account': {
                 'name': None,
                 'domain': None,
             },
             'path': '/{0}'.format(data['name']),
-            'full_path': None
+            'full_path': None,
+            'vault_object_name': data['name'],
         }
         self.object.update(data)
+
+        if not self.object['vault_name']:
+            self.object['vault_name'] = 'mock_vault'
+
+        if not self.object['path']:
+            self.object['path'] = '/{0}'.format(self.object['name'])
+
+        if not self.object['full_path']:
+            self.object['full_path'] = 'solvebio:{0}:{1}'.format(
+                self.object['vault_name'], self.object['path'])
 
 
 class FakeDatasetTemplateResponse(Fake201Response):

--- a/solvebio/test/client_mocks.py
+++ b/solvebio/test/client_mocks.py
@@ -40,6 +40,21 @@ class Fake201Response(object):
 
         return ExtendedList([self.create()])
 
+    def update_paths(self):
+        """Sets vault_name, path and full_path"""
+        if not self.object['vault_name']:
+            self.object['vault_name'] = 'mock_vault'
+
+        if not self.object['path']:
+            self.object['path'] = '/{0}'.format(
+                self.object.get(
+                    'filename', self.object.get('vault_object_filename'))
+            )
+
+        if not self.object['full_path']:
+            self.object['full_path'] = 'solvebio:{0}:{1}'.format(
+                self.object['vault_name'], self.object['path'])
+
 
 class FakeMigrationResponse(Fake201Response):
 
@@ -99,8 +114,14 @@ class FakeObjectResponse(Fake201Response):
             'size': None,
             'md5': None,
             'filename': 'file.json.gz',
+            'path': None,
+            'full_path': None,
+            'vault_name': None,
+            'vault_id': None,
             'object_type': 'folder'
         }
+        self.object.update(data)
+        self.update_paths()
 
 
 class FakeDatasetResponse(Fake201Response):
@@ -122,16 +143,7 @@ class FakeDatasetResponse(Fake201Response):
             'vault_object_name': data['name'],
         }
         self.object.update(data)
-
-        if not self.object['vault_name']:
-            self.object['vault_name'] = 'mock_vault'
-
-        if not self.object['path']:
-            self.object['path'] = '/{0}'.format(self.object['name'])
-
-        if not self.object['full_path']:
-            self.object['full_path'] = 'solvebio:{0}:{1}'.format(
-                self.object['vault_name'], self.object['path'])
+        self.update_paths()
 
 
 class FakeDatasetTemplateResponse(Fake201Response):

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -170,6 +170,14 @@ class CLITests(SolveBioTestCase):
         self.assertEqual(ds.full_path, 'solvebio:mock_vault:/test-dataset')
         self.assertEqual(ds.tags, ['hello'])
 
+        # Non-existent file
+        args = ['import', '--create-dataset', '--tag', 'hello', '--follow',
+                'solvebio:mock_vault:/test-dataset',
+                'not/a/real/path/file.txt']
+
+        with self.assertRaises(ValueError):
+            self._test_import_file(args)
+
     def test_import_tilde(self):
         _, file_ = tempfile.mkstemp(suffix='.txt')
         with open(file_, 'w') as fp:
@@ -182,6 +190,15 @@ class CLITests(SolveBioTestCase):
             args = ['import', '--create-dataset', dataset_path, file_]
             ds = self._test_import_file(args)
             self.assertEqual(ds.name, 'test-dataset')
+
+    def test_import_remote_file(self):
+        args = ['import', '--create-dataset', '--tag', 'hello',
+                '--remote-source', 'solvebio:mock_vault:/test-dataset',
+                '/this/is/a/remote/file', '/this/remote/*/path']
+
+        ds = self._test_import_file(args)
+        self.assertEqual(ds.full_path, 'solvebio:mock_vault:/test-dataset')
+        self.assertEqual(ds.tags, ['hello'])
 
     @mock.patch(
         'solvebio.resource.apiresource.ListableAPIResource._retrieve_helper')

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -62,13 +62,15 @@ class CLITests(SolveBioTestCase):
         DatasetCreate.side_effect = fake_dataset_create
         ObjectAll.side_effect = fake_object_all
         VaultAll.side_effect = fake_vault_all
-        args = ['create-dataset', 'test-dataset-filename',
-                '--vault', 'solvebio:test_vault',
-                '--path', '/',
-                '--capacity', 'small']
+        args = [
+            'create-dataset',
+            'solvebio:test_vault:/test-dataset-filename',
+            '--capacity', 'small'
+        ]
         ds = main.main(args)
         self.assertEqual(ds.name, 'test-dataset-filename')
         self.assertEqual(ds.path, '/test-dataset-filename')
+        self.assertEqual(ds.capacity, 'small')
 
     def _validate_tmpl_fields(self, fields):
         for f in fields:


### PR DESCRIPTION
## Create Dataset

- pass `--tag` values to add tags to the dataset
- pass `--metadata` vaults to add metadata key value paris
- pass `--metadata-json-file` to pass a JSON file of complex metadata

Breaking Changes
- fails if dataset already exists
- remove `vault` and `path` command overrides. Complete transition to `full_path`

## Import data command

- Inherits all new features above for creating datasets (via --create-dataset)
- pass `--remote-source` command toggles the `file` arguments to be remote paths

Breaking Changes 
- Inherits all breaking changes above for creating datasets (via --create-dataset)
