### PR TITLE
CLI to download multiple files

### DIFF
--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -478,7 +478,7 @@ def download(args):
 
     if sb_object.is_file:
         sb_object.download(local_folder_path)
-        print(f'Downloaded: {sb_object.full_path}')
+        print('Downloaded: {}'.format(sb_object.full_path))
 
     elif sb_object.is_folder:
         files = sb_object.files(query=query) if query else sb_object.files()
@@ -489,10 +489,10 @@ def download(args):
         for file in files:
             file_obj = Object.retrieve(file.id)
             file_obj.download(local_folder_path)
-            print(f'Downloaded: {file.full_path}')
+            print('Downloaded: {}'.format(file.full_path))
 
     else:
-        print(f'ERROR: {sb_object.full_path} is not file or folder.')
+        print('ERROR: {} is not file or folder.'.format(sb_object.full_path))
 
 
 def should_tag_by_object_type(args, object_):

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -460,6 +460,41 @@ def import_file(args):
     return imports, dataset
 
 
+def download(args):
+    """
+    Given a folder or file, download all the files contained within it (not recursive).
+    """
+    local_folder_path = args.local_path
+    sb_path = args.full_path
+    query = args.query
+
+    base_remote_path, path_dict = Object.validate_full_path(sb_path)
+
+    sb_object = Object.get_by_full_path(base_remote_path)
+
+    # If user sets the home directory, expand the path
+    local_folder_path = os.path.expanduser(local_folder_path) if local_folder_path.startswith(
+        '~') else local_folder_path
+
+    if sb_object.is_file:
+        sb_object.download(local_folder_path)
+        print(f'Downloaded: {sb_object.full_path}')
+
+    elif sb_object.is_folder:
+        files = sb_object.files(query=query) if query else sb_object.files()
+
+        if not os.path.exists(local_folder_path):
+            os.makedirs(local_folder_path, exist_ok=True)
+
+        for file in files:
+            file_obj = Object.retrieve(file.id)
+            file_obj.download(local_folder_path)
+            print(f'Downloaded: {file.full_path}')
+
+    else:
+        print(f'ERROR: {sb_object.full_path} is not file or folder.')
+
+
 def should_tag_by_object_type(args, object_):
     """Returns True if object matches object type requirements"""
     valid = True

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -487,7 +487,7 @@ def _download(full_path, local_folder_path, dry_run=False):
     # Add */** to match in any vault (recursive)
     files = Object.all(glob=full_path, limit=1000, object_type='file')
     if not files:
-        print("No file(s) found at --full-path {}\nIf aattempting to download "
+        print("No file(s) found at --full-path {}\nIf attempting to download "
               "multiple files, try using a glob 'vault:/path/folder/*'"
               .format(full_path))
 

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -477,12 +477,11 @@ def _download(full_path, local_folder_path, dry_run=False):
         print('Running in dry run mode. Not downloading any files.')
 
     local_folder_path = os.path.expanduser(local_folder_path)
-    base_remote_path, path_dict = Object.validate_full_path(full_path)
-
     if not os.path.exists(local_folder_path):
         print("Creating local download folder {}".format(local_folder_path))
         if not dry_run:
-            os.makedirs(local_folder_path, exist_ok=True)
+            if not os.path.exists(local_folder_path):
+                os.makedirs(local_folder_path)
 
     # API will determine depth based on number of "/" in the glob
     # Add */** to match in any vault (recursive)

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -465,30 +465,38 @@ def download(args):
     Given a folder or file, download all the files contained
     within it (not recursive).
     """
-    # Always expand ~ in local path
-    local_folder_path = os.path.expanduser(args.local_path)
+    return _download(args.full_path, args.local_path, dry_run=args.dry_run)
 
-    if args.dry_run:
+
+def _download(full_path, local_folder_path, dry_run=False):
+    """
+    Given a folder or file, download all the files contained
+    within it (not recursive).
+    """
+    if dry_run:
         print('Running in dry run mode. Not downloading any files.')
 
-    base_remote_path, path_dict = Object.validate_full_path(args.full_path)
+    local_folder_path = os.path.expanduser(local_folder_path)
+    base_remote_path, path_dict = Object.validate_full_path(full_path)
 
     if not os.path.exists(local_folder_path):
         print("Creating local download folder {}".format(local_folder_path))
-        if not args.dry_run:
+        if not dry_run:
             os.makedirs(local_folder_path, exist_ok=True)
 
     # API will determine depth based on number of "/" in the glob
     # Add */** to match in any vault (recursive)
-    files = Object.all(glob=args.full_path, limit=1000, object_type='file')
+    files = Object.all(glob=full_path, limit=1000, object_type='file')
     if not files:
         print("No file(s) found at --full-path {}\nIf aattempting to download "
               "multiple files, try using a glob 'vault:/path/folder/*'"
-              .format(args.full_path))
+              .format(full_path))
 
     for file_ in files:
-        if not args.dry_run:
+
+        if not dry_run:
             file_.download(local_folder_path)
+
         print('Downloaded: {} to {}/{}'.format(
             file_.full_path, local_folder_path, file_.filename))
 

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -265,18 +265,17 @@ class SolveArgumentParser(argparse.ArgumentParser):
             'help': 'Download one or more files from a SolveBio Vault.',
             'arguments': [
                 {
-                    'flags': '--full-path',
-                    'help': 'The full path to the files on SolveBio. Supports '
-                    'Unix style globs in order to download multiple files. '
-                    'Note: Downloads are not recursive.',
-                    'required': True,
-                    'action': TildeFixStoreAction
-                },
-                {
                     'flags': '--dry-run',
                     'help': 'Dry run mode will not download any files or '
                     'create any folders.',
                     'action': 'store_true'
+                },
+                {
+                    'flags': 'full_path',
+                    'help': 'The full path to the files on SolveBio. Supports '
+                    'Unix style globs in order to download multiple files. '
+                    'Note: Downloads are not recursive.',
+                    'action': TildeFixStoreAction
                 },
                 {
                     'name': 'local_path',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -268,6 +268,8 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 {
                     'flags': '--full-path',
                     'help': 'The full path where the files are located in SolveBio.',
+                    'action': TildeFixStoreAction,
+                    'default': '~/'
                 },
                 {
                     'flags': '--query',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -260,6 +260,26 @@ class SolveArgumentParser(argparse.ArgumentParser):
                 }
             ]
         },
+        'download': {
+            'func': data.download,
+            'help': 'Download a file or directory from a SolveBio Vault. Not recursive '
+                    '(will download only files in specified folder).',
+            'arguments': [
+                {
+                    'flags': '--full-path',
+                    'help': 'The full path where the files are located in SolveBio.',
+                },
+                {
+                    'flags': '--query',
+                    'help': 'Can be used to filter only needed files from folder (for example, ".vcf").',
+                },
+                {
+                    'name': 'local_path',
+                    'help': 'The path to the local directory where '
+                            'to download files.',
+                }
+            ]
+        },
         'tag': {
             'func': data.tag,
             'help': 'Apply tags or remove tags on objects',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -269,6 +269,7 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     'help': 'The full path to the files on SolveBio. Supports '
                     'Unix style globs in order to download multiple files. '
                     'Note: Downloads are not recursive.',
+                    'required': True,
                     'action': TildeFixStoreAction
                 },
                 {

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -262,18 +262,25 @@ class SolveArgumentParser(argparse.ArgumentParser):
         },
         'download': {
             'func': data.download,
-            'help': 'Download a file or directory from a SolveBio Vault. Not recursive '
+            'help': 'Download a file or directory from a Vault. Not recursive '
                     '(will download only files in specified folder).',
             'arguments': [
                 {
                     'flags': '--full-path',
-                    'help': 'The full path where the files are located in SolveBio.',
+                    'help': 'The full path to the files on SolveBio',
                     'action': TildeFixStoreAction,
                     'default': '~/'
                 },
                 {
                     'flags': '--query',
-                    'help': 'Can be used to filter only needed files from folder (for example, ".vcf").',
+                    'help': 'Can be used to filter only needed files '
+                            'from folder (for example, ".vcf").',
+                },
+                {
+                    'flags': '--dry-run',
+                    'help': 'Dry run mode will not download any files or '
+                    'create any folders.',
+                    'action': 'store_true'
                 },
                 {
                     'name': 'local_path',

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -262,19 +262,14 @@ class SolveArgumentParser(argparse.ArgumentParser):
         },
         'download': {
             'func': data.download,
-            'help': 'Download a file or directory from a Vault. Not recursive '
-                    '(will download only files in specified folder).',
+            'help': 'Download one or more files from a SolveBio Vault.',
             'arguments': [
                 {
                     'flags': '--full-path',
-                    'help': 'The full path to the files on SolveBio',
-                    'action': TildeFixStoreAction,
-                    'default': '~/'
-                },
-                {
-                    'flags': '--query',
-                    'help': 'Can be used to filter only needed files '
-                            'from folder (for example, ".vcf").',
+                    'help': 'The full path to the files on SolveBio. Supports '
+                    'Unix style globs in order to download multiple files. '
+                    'Note: Downloads are not recursive.',
+                    'action': TildeFixStoreAction
                 },
                 {
                     'flags': '--dry-run',

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -393,13 +393,11 @@ class CLITests(SolveBioTestCase):
         return main.main(args)
 
     def test_download_file(self):
-        args = ['download', '--full-path',
-                'solvebio:mock_vault:/test-file', '.']
+        args = ['download', 'solvebio:mock_vault:/test-file', '.']
         self._test_download_file(args)
         self.assertFalse(os.path.exists('.test-file'))
 
-        args = ['download', '--full-path',
-                'solvebio:mock_vault:/test-file/*', '.']
+        args = ['download', 'solvebio:mock_vault:/test-file/*', '.']
         self._test_download_file(args)
         self.assertFalse(os.path.exists('.test-file'))
 
@@ -414,11 +412,10 @@ class CLITests(SolveBioTestCase):
             self._test_download_file(args)
 
         # local path required
-        args = ['download', '--full-path', 'my-vault:/mypath']
+        args = ['download', 'my-vault:/mypath']
         with self.assertRaises(SystemExit):
             self._test_download_file(args)
 
-        args = ['download', '--full-path',
-                'solvebio:mock_vault:/test-file/*', '.']
+        args = ['download', 'solvebio:mock_vault:/test-file/*', '.']
         with self.assertRaises(Exception):
             self._test_download_file(args, download_success=False)


### PR DESCRIPTION
Builds off of https://github.com/solvebio/solvebio-python/pull/325

```
 $ solvebio download --help
usage: solvebio download [-h] [--version] [--api-host API_HOST]
                         [--api-key API_KEY] [--access-token ACCESS_TOKEN]
                         [--dry-run]
                         full_path local_path

positional arguments:
  local_path            The path to the local directory where to download
                               files.
  full_path      The full path to the files on SolveBio. Supports Unix
                        style globs in order to download multiple files. Note:
                        Downloads are not recursive.
SolveBio Options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --api-host API_HOST   Override the default SolveBio API host
  --api-key API_KEY     Manually provide a SolveBio API key
  --access-token ACCESS_TOKEN
                        Manually provide a SolveBio OAuth2 access token
  --dry-run             Dry run mode will not download any files or create any
                        folders.
```