### PR TITLE
Object tagging updates

### DIFF
--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -501,7 +501,8 @@ class Object(CreateableAPIResource,
                       .format('[Dry Run] ' if dry_run else '',
                               ', '.join(removal_tags), self.full_path))
 
-                updated_tags = [tag for tag in tags if not self.has_tag(tag)]
+                tags_for_removal = [tag for tag in tags if self.has_tag(tag)]
+                updated_tags = [tag for tag in self.tags if tag not in tags_for_removal]
             else:
                 print('{}Notice: Object {} does not contain any of the '
                       'following tags: {}'.format(

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -1,4 +1,5 @@
 """Solvebio Object API resource"""
+import collections
 import os
 import re
 import base64
@@ -6,6 +7,7 @@ import binascii
 import mimetypes
 
 import requests
+import six
 from requests.packages.urllib3.util.retry import Retry
 
 from solvebio.errors import SolveError
@@ -484,15 +486,24 @@ class Object(CreateableAPIResource,
         return self.object_type == 'file'
 
     def has_tag(self, tag):
-        """Return True if object contains tags"""
+        """Return True if object contains tag"""
 
         def lowercase(x):
             return x.lower()
 
-        return lowercase(tag) in map(lowercase, self.tags)
+        return lowercase(str(tag)) in map(lowercase, self.tags)
 
     def tag(self, tags, remove=False, dry_run=False, apply_save=True):
         """Add or remove tags on an object"""
+
+        def iterable(arg):
+            return (isinstance(arg, collections.Iterable) and
+                    not isinstance(arg, six.string_types))
+
+        if not iterable(tags):
+            tags = [str(tags)]
+        else:
+            tags = [str(tag) for tag in tags]
 
         if remove:
             removal_tags = [tag for tag in tags if self.has_tag(tag)]

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -491,7 +491,7 @@ class Object(CreateableAPIResource,
 
         return lowercase(tag) in map(lowercase, self.tags)
 
-    def tag(self, tags, remove=False, dry_run=False, apply_save=False):
+    def tag(self, tags, remove=False, dry_run=False, apply_save=True):
         """Add or remove tags on an object"""
 
         if remove:
@@ -528,7 +528,7 @@ class Object(CreateableAPIResource,
 
         return True
 
-    def untag(self, tags, dry_run=False, apply_save=False):
+    def untag(self, tags, dry_run=False, apply_save=True):
         """Remove tags on an object"""
 
         return self.tag(tags=tags, remove=True, dry_run=dry_run, apply_save=apply_save)

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -532,6 +532,4 @@ class Object(CreateableAPIResource,
     def untag(self, tags, dry_run=False, apply_save=False):
         """Remove tags on an object"""
 
-        untag_part = partial(self.tag, remove=True)
-
-        return untag_part(tags=tags, dry_run=dry_run, apply_save=apply_save)
+        return self.tag(tags=tags, remove=True, dry_run=dry_run, apply_save=apply_save)

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -496,11 +496,13 @@ class Object(CreateableAPIResource,
     def tag(self, tags, remove=False, dry_run=False, apply_save=True):
         """Add or remove tags on an object"""
 
-        def iterable(arg):
+        def is_iterable_non_string(arg):
+            """python2/python3 compatible way to check if arg is an iterable but not string"""
+
             return (isinstance(arg, collections.Iterable) and
                     not isinstance(arg, six.string_types))
 
-        if not iterable(tags):
+        if not is_iterable_non_string(tags):
             tags = [str(tags)]
         else:
             tags = [str(tag) for tag in tags]

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -4,6 +4,7 @@ import re
 import base64
 import binascii
 import mimetypes
+from functools import partial
 
 import requests
 from requests.packages.urllib3.util.retry import Retry
@@ -527,3 +528,10 @@ class Object(CreateableAPIResource,
             self.save()
 
         return True
+
+    def untag(self, tags, dry_run=False, apply_save=False):
+        """Remove tags on an object"""
+
+        untag_part = partial(self.tag, remove=True)
+
+        return untag_part(tags=tags, dry_run=dry_run, apply_save=apply_save)

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -4,7 +4,6 @@ import re
 import base64
 import binascii
 import mimetypes
-from functools import partial
 
 import requests
 from requests.packages.urllib3.util.retry import Retry

--- a/solvebio/test/client_mocks.py
+++ b/solvebio/test/client_mocks.py
@@ -10,7 +10,7 @@ class Fake201Response(object):
 
     def __init__(self, data):
         self.object = {
-            'id': 100,
+            'id': data.get('id', 100),
             'class_name': self.class_name
         }
 
@@ -19,6 +19,9 @@ class Fake201Response(object):
 
     def create(self, *args, **kwargs):
         return convert_to_solve_object(self.object)
+
+    def save(self, *args, **kwargs):
+        return self.create(*args, **kwargs)
 
     def retrieve(self, r_id, *args, **kwargs):
         obj = self.create()
@@ -247,6 +250,10 @@ def fake_object_all(*args, **kwargs):
 
 def fake_object_create(*args, **kwargs):
     return FakeObjectResponse(kwargs).create()
+
+
+def fake_object_save(*args, **kwargs):
+    return FakeObjectResponse(kwargs).save()
 
 
 def fake_object_retrieve(*args, **kwargs):

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -206,15 +206,15 @@ class ObjectTests(SolveBioTestCase):
         for tag in tags:
             self.assertTrue(file_.has_tag(tag))
 
-        tags_for_removal = ['tag1', 'tag2']
-        file_.untag(tags=tags_for_removal, apply_save=True)
+        tags_for_untagging = ['tag1', 'tag2']
+        file_.untag(tags=tags_for_untagging, apply_save=True)
 
-        # test that given tags are removed
-        for tag in tags_for_removal:
+        # test that given tags are untagged
+        for tag in tags_for_untagging:
             self.assertFalse(file_.has_tag(tag))
 
-        updated_tags = [tag for tag in tags if tag not in tags_for_removal]
+        updated_tags = [tag for tag in tags if tag not in tags_for_untagging]
 
-        # test that tags which have not been removed are still there
+        # test that tags which have not been untagged are still there
         for tag in updated_tags:
             self.assertTrue(file_.has_tag(tag))

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -218,3 +218,21 @@ class ObjectTests(SolveBioTestCase):
         # test that tags which have not been untagged are still there
         for tag in updated_tags:
             self.assertTrue(file_.has_tag(tag))
+
+    @mock.patch('solvebio.resource.Object.create')
+    @mock.patch('solvebio.resource.Object.save')
+    def test_object_add_tag_non_iterable_or_string(self, ObjectCreate, ObjectSave):
+        ObjectCreate.side_effect = fake_object_create
+        ObjectSave.side_effect = fake_object_save
+
+        # test that a string is added propery
+        tags = 'tag1'
+        file_ = self.client.Object.create(filename='foo_file',
+                                          object_type='file')
+        file_.tag(tags)
+        self.assertTrue(file_.has_tag(tags))
+
+        # test that non iterable (e.g. integer) added properly
+        tags = 1
+        file_.tag(tags)
+        self.assertTrue(file_.has_tag(tags))

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import mock
 
 from .helper import SolveBioTestCase
-from solvebio.test.client_mocks import fake_object_create
+from solvebio.test.client_mocks import fake_object_create, fake_object_save
 from solvebio.test.client_mocks import fake_dataset_create
 
 
@@ -166,3 +166,55 @@ class ObjectTests(SolveBioTestCase):
         for obj in [file_, folder_, ds, ds_obj]:
             with self.assertRaises(AttributeError):
                 getattr(obj, fake_attr)
+
+    @mock.patch('solvebio.resource.Object.create')
+    @mock.patch('solvebio.resource.Object.save')
+    def test_object_remove_tag(self, ObjectCreate, ObjectSave):
+        ObjectCreate.side_effect = fake_object_create
+        ObjectSave.side_effect = fake_object_save
+
+        tags = ['tag1', 'tag2', 'tag3']
+        file_ = self.client.Object.create(filename='foo_file',
+                                          object_type='file',
+                                          tags=tags)
+        for tag in tags:
+            self.assertTrue(file_.has_tag(tag))
+
+        tags_for_removal = ['tag1', 'tag2']
+        file_.tag(tags=tags_for_removal, remove=True, apply_save=True)
+
+        # test that given tags are removed
+        for tag in tags_for_removal:
+            self.assertFalse(file_.has_tag(tag))
+
+        updated_tags = [tag for tag in tags if tag not in tags_for_removal]
+
+        # test that tags which have not been removed are still there
+        for tag in updated_tags:
+            self.assertTrue(file_.has_tag(tag))
+
+    @mock.patch('solvebio.resource.Object.create')
+    @mock.patch('solvebio.resource.Object.save')
+    def test_object_untag(self, ObjectCreate, ObjectSave):
+        ObjectCreate.side_effect = fake_object_create
+        ObjectSave.side_effect = fake_object_save
+
+        tags = ['tag1', 'tag2', 'tag3']
+        file_ = self.client.Object.create(filename='foo_file',
+                                          object_type='file',
+                                          tags=tags)
+        for tag in tags:
+            self.assertTrue(file_.has_tag(tag))
+
+        tags_for_removal = ['tag1', 'tag2']
+        file_.untag(tags=tags_for_removal, apply_save=True)
+
+        # test that given tags are removed
+        for tag in tags_for_removal:
+            self.assertFalse(file_.has_tag(tag))
+
+        updated_tags = [tag for tag in tags if tag not in tags_for_removal]
+
+        # test that tags which have not been removed are still there
+        for tag in updated_tags:
+            self.assertTrue(file_.has_tag(tag))


### PR DESCRIPTION
- fixes tag removal bug (resolves #347 )
- change `<object>.tag(my_tag)` command to save the tag by default (previously `apply_save=False` by default)
- add a shortcut `untag()` that removes a tag 
- allow a single tag in the `tag()` and `untag()` commands  (previously required a list)
- docs available here https://docs.solvebio.com/vaults/basics/#metadata-and-tags
