### PR TITLE
Fix for multiple join errors

### DIFF
--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -854,8 +854,7 @@ class Query(QueryBase):
         new_query = self._clone()
 
         # Initialize _explode_fields attribute if it does not exist
-        new_query._explode_fields = [] if not getattr(self, '_explode_fields', None) \
-            else self._explode_fields
+        new_query._explode_fields = getattr(self, '_explode_fields', None) or []
 
         # Set list of existing field names to avoid overwriting fields
         # in the join.

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -941,8 +941,8 @@ class Query(QueryBase):
         new_query._target_fields += target_fields
 
         new_query._annotator_params = {
-            'post_annotation_expression': "explode(record, fields={})".
-                format(new_query._explode_fields)
+            'post_annotation_expression':
+                "explode(record, fields={})".format(new_query._explode_fields)
         }
         new_query._is_join = True
         return new_query

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -874,7 +874,7 @@ class Query(QueryBase):
 
         # If a joining key in both datasets is the same and
         # it is not the only one field then remove it from query_b
-        if key_b == key and len(query_b_fields) == 1 and query_b_fields[0].name != key_b:
+        if key_b == key and not (len(query_b_fields) == 1 and query_b_fields[0].name == key_b):
             query_b_fields = [item for item in query_b_fields if not item.name == key_b]
 
         query_b_join_field_name = "join_{}".format(join_id)
@@ -904,7 +904,6 @@ class Query(QueryBase):
         ]
 
         # Get list of fields to join from query B
-        explode_fields = []
         for field in query_b_fields:
             # If "always prefix" is enable, or the field name is found
             # in existing list of names, add the prefix.
@@ -912,8 +911,6 @@ class Query(QueryBase):
                 name = prefix + field.name
             else:
                 name = field.name
-
-            explode_fields.append(name)
 
             if name in existing_field_names:
                 raise Exception("Field '{}' found in both queries, "

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -853,6 +853,10 @@ class Query(QueryBase):
         # Prepare new returned query object
         new_query = self._clone()
 
+        # Initialize _explode_fields attribute if it does not exist
+        new_query._explode_fields = [] if not getattr(self, '_explode_fields', None) \
+            else self._explode_fields
+
         # Set list of existing field names to avoid overwriting fields
         # in the join.
         existing_field_names = [f.name for f in self.fields()]
@@ -873,7 +877,7 @@ class Query(QueryBase):
         query_b_fields = query_b.fields()
 
         # If a joining key in both datasets is the same and
-        # it is not the only one field then remove it from query_b
+        # it is not the only one field in a query_b then remove it from query_b
         if key_b == key and not (len(query_b_fields) == 1 and query_b_fields[0].name == key_b):
             query_b_fields = [item for item in query_b_fields if not item.name == key_b]
 
@@ -916,6 +920,9 @@ class Query(QueryBase):
                 raise Exception("Field '{}' found in both queries, "
                                 "please use a different prefix.".format(name))
 
+            # Add a newly created field to list that will be passed to the explode function
+            new_query._explode_fields.append(name)
+
             target_fields.append({
                 "name": name,
                 "title": field.title,
@@ -933,11 +940,9 @@ class Query(QueryBase):
         # Add to any existing target fields
         new_query._target_fields += target_fields
 
-        # Extend explode_fields with prefixed fields to be exploded
-        explode_fields = [field['name'] for field in new_query._target_fields if 'join' not in field['name']]
-
         new_query._annotator_params = {
-            'post_annotation_expression': "explode(record, fields={})".format(explode_fields)
+            'post_annotation_expression': "explode(record, fields={})".
+                format(new_query._explode_fields)
         }
         new_query._is_join = True
         return new_query

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -384,3 +384,16 @@ class BaseQueryTest(SolveBioTestCase):
             for key, value in row.items():
                 if 'b_' in key:
                     self.assertEqual(value, None)
+
+    def test_join_multiple_join(self):
+        query_a = self.dataset2.query(fields=['gene'], limit=1).filter(gene='MAN2B1')
+        query_b = self.dataset2.query(fields=['gene'])
+        query_c = self.dataset2.query(fields=['gene'])
+
+        join_query = query_a.join(query_b, key='gene', prefix='b_')
+        multiple_join_query = join_query.join(query_c, key='gene', prefix='c_')
+
+        for record in multiple_join_query:
+            self.assertTrue('gene' in record)
+            self.assertTrue('b_gene' in record)
+            self.assertTrue('c_gene' in record)

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -383,4 +383,4 @@ class BaseQueryTest(SolveBioTestCase):
         for row in join_query:
             for key, value in row.items():
                 if 'b_' in key:
-                    self.assertEqual(value, [])
+                    self.assertEqual(value, None)


### PR DESCRIPTION
- Fix the prefix issue when two fields after adding a prefix have the same name
- Add newly prefixed fields to the `explode_fields` list in order to be taken into an account for exploding.