### PR TITLE
Update Travis to Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+dist: bionic
 language: python
 python:
 - '2.7'
 - '3.6'
 - '3.7'
 - '3.8'
-- 'pypy'
+- 'pypy2'
 - 'pypy3'
 before_install:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)


### PR DESCRIPTION
Pypy is called pypy2 in bionic dist for Travis: https://docs.travis-ci.com/user/languages/python/#python-versions