### PR TITLE
Flatten lists of lists instead of using "object" data type in joins

### DIFF
--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -922,19 +922,27 @@ class Query(QueryBase):
             # Add a newly created field to list that will be passed to the explode function
             new_query._explode_fields.append(name)
 
+            # Extract all the field values from each joined record
+            expression = '[get(item, "{}") for item in get(record, "{}")]'.format(
+                field.name, query_b_join_field_name)
+
+            if field.is_list:
+                # Handle case where the sub-query contains a list of lists of <field.data_type>,
+                # which will happen if the field contains a list of values.
+                # In this case, we will flatten it to avoid returning a list of lists.
+                expression = '[item for sublist in ' + expression + ' for item in sublist]'
+
             target_fields.append({
                 "name": name,
                 "title": field.title,
-                # Handle case where sub-query returns a list of lists (of strings or something)
-                "data_type": "object" if field.is_list else field.data_type,
+                "data_type": field.data_type,
                 "ordering": field.ordering,
                 "is_list": True,
                 "is_transient": False,
-                "expression": """
-                    [get(item, "{}") for item in get(record, "{}")]
-                """.format(field.name, query_b_join_field_name),
+                "expression": expression,
                 "depends_on": [query_b_join_field_name]
             })
+
 
         # Add to any existing target fields
         new_query._target_fields += target_fields

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -943,14 +943,16 @@ class Query(QueryBase):
                 "depends_on": [query_b_join_field_name]
             })
 
-
         # Add to any existing target fields
         new_query._target_fields += target_fields
 
-        new_query._annotator_params = {
-            'post_annotation_expression':
-                "explode(record, fields={})".format(new_query._explode_fields)
-        }
+        # Preserve existing annotator params (pre_annotation_expression only)
+        if not new_query._annotator_params:
+            new_query._annotator_params = {}
+
+        new_query._annotator_params['post_annotation_expression'] = \
+            "explode(record, fields={})".format(new_query._explode_fields)
+
         new_query._is_join = True
         return new_query
 

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -415,7 +415,7 @@ class BaseQueryTest(SolveBioTestCase):
             .limit(10)
 
         for i in query_a.join(query_b, "clinical_significance"):
-            self.assertTrue(isinstance(i['clinical_significance'], str))
+            self.assertFalse(isinstance(i['clinical_significance'], list))
             self.assertTrue('_errors' not in i)
 
     def test_join_with_list_values(self):
@@ -438,6 +438,6 @@ class BaseQueryTest(SolveBioTestCase):
         for i in query_a.join(query_b, "variant"):
             # Since each value contains one element, the resulting output is just a flat string
             # as the API takes the first value in the list.
-            self.assertTrue(isinstance(i['clinical_significance'], str))
-            self.assertTrue(isinstance(i['b_clinical_significance'], str))
+            self.assertFalse(isinstance(i['clinical_significance'], list))
+            self.assertFalse(isinstance(i['b_clinical_significance'], list))
             self.assertTrue('_errors' not in i)

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -397,3 +397,47 @@ class BaseQueryTest(SolveBioTestCase):
             self.assertTrue('gene' in record)
             self.assertTrue('b_gene' in record)
             self.assertTrue('c_gene' in record)
+
+    def test_join_with_list_key(self):
+        """Test a join where the key is a list. In this case, clinical_significance is a list.
+        Ensure that the output contains a single value in each resulting record."""
+
+        annotator_params = {"pre_annotation_expression": "explode(record, ['clinical_significance'])"}
+        query_a = self.dataset2\
+            .query(
+                fields=['clinical_significance', 'variant'],
+                annotator_params=annotator_params)\
+            .filter(gene='MAN2B1')\
+            .limit(10)
+        query_b = self.dataset2\
+            .query(fields=['clinical_significance', 'gene'])\
+            .filter(gene='MAN2B1')\
+            .limit(10)
+
+        for i in query_a.join(query_b, "clinical_significance"):
+            self.assertTrue(isinstance(i['clinical_significance'], str))
+            self.assertTrue('_errors' not in i)
+
+    def test_join_with_list_values(self):
+        """Test a join where one of the fields is a list.
+        In this case, clinical_significance is a list.
+        Ensure that the output contains a list of strings (not lists)."""
+
+        annotator_params = {"pre_annotation_expression": "explode(record, ['clinical_significance'])"}
+        query_a = self.dataset2\
+            .query(
+                fields=['clinical_significance', 'variant'],
+                annotator_params=annotator_params)\
+            .filter(gene='MAN2B1')\
+            .limit(10)
+        query_b = self.dataset2\
+            .query(fields=['clinical_significance', 'gene', 'variant'])\
+            .filter(gene='MAN2B1')\
+            .limit(10)
+
+        for i in query_a.join(query_b, "variant"):
+            # Since each value contains one element, the resulting output is just a flat string
+            # as the API takes the first value in the list.
+            self.assertTrue(isinstance(i['clinical_significance'], str))
+            self.assertTrue(isinstance(i['b_clinical_significance'], str))
+            self.assertTrue('_errors' not in i)


### PR DESCRIPTION
Handle the case where a join returns a list of lists. Instead of setting the data type to "object", flatten the results. This fixes issues that can come up when migrating the output of the join. 

closes #380 

Also, preserve annotator_params (specifically pre_annotation_expression) when running a join. This allows keys containing lists of values to be joined.