### PR TITLE
Handle a query slicing when the potential number of returned records in the query is larger than the number of records left in the dataset/file

### DIFF
--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -409,7 +409,12 @@ class QueryBase(object):
             self.__iter__()
 
         # len(self) returns `min(limit, total)` results
-        if self._cursor == len(self):
+        # Raise StopIteration when query()[n:] has been exhausted
+        if self._slice and self._slice.stop == float('inf') and self._cursor == len(self) - 1:
+            raise StopIteration()
+
+        # Raise StopIteration when query()[n:m] has been exhausted
+        elif self._cursor == len(self):
             raise StopIteration()
 
         if self._buffer_idx == len(self._buffer):

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -416,11 +416,11 @@ class QueryBase(object):
             self.execute(self._page_offset + self._buffer_idx)
             self._buffer_idx = 0
 
+        if not self._buffer:
+            raise StopIteration()
+
         self._cursor += 1
         self._buffer_idx += 1
-
-        if not self._buffer:
-            raise StopIteration
 
         return self._buffer[self._buffer_idx - 1]
 

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -409,7 +409,7 @@ class QueryBase(object):
             self.__iter__()
 
         # len(self) returns `min(limit, total)` results
-        elif self._cursor == len(self):
+        if self._cursor == len(self):
             raise StopIteration()
 
         if self._buffer_idx == len(self._buffer):

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -409,11 +409,6 @@ class QueryBase(object):
             self.__iter__()
 
         # len(self) returns `min(limit, total)` results
-        # Raise StopIteration when query()[n:] has been exhausted
-        if self._slice and self._slice.stop == float('inf') and self._cursor == len(self) - 1:
-            raise StopIteration()
-
-        # Raise StopIteration when query()[n:m] has been exhausted
         elif self._cursor == len(self):
             raise StopIteration()
 
@@ -423,6 +418,9 @@ class QueryBase(object):
 
         self._cursor += 1
         self._buffer_idx += 1
+
+        if not self._buffer:
+            raise StopIteration
 
         return self._buffer[self._buffer_idx - 1]
 

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -229,6 +229,18 @@ class BaseQueryTest(SolveBioTestCase):
         # Ensure that the second repr for [0:2] == [1:3]
         self.assertEqual(repr(zero_two[1]), repr(one_three[0]))
 
+    def test_slice_until_dataset_end(self):
+        total = self.dataset.query(limit=0).count()
+
+        sliced_ds = self.dataset.query(limit=10)[total - 1:]
+
+        left_records = 0
+        for _ in sliced_ds:
+            left_records += 1
+
+        # Ensure that only one records has left in the dataset
+        self.assertEqual(left_records, 1)
+
     def test_slice_ranges_with_small_limit(self):
         # Test slices larger than 'limit'
         # query returns 6


### PR DESCRIPTION
Slicing results of dataset/file query raises an error when the `stop` param is set to `float('inf').

closes #385 