### PR TITLE
Global Beacon interface update

### DIFF
--- a/examples/global_beacon_indexing.ipynb
+++ b/examples/global_beacon_indexing.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +45,7 @@
        "True"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -84,12 +84,12 @@
        "|            availability | available                                          |\n",
        "|              class_name | Object                                             |\n",
        "|              created_at | 2021-11-29T11:24:42.093Z                           |\n",
-       "|     dataset_description | test                                               |\n",
+       "|     dataset_description | Test dataset for global beacon                     |\n",
        "| dataset_documents_count | 26312                                              |\n",
        "|       dataset_full_name | 1658666726768179211                                |\n",
        "|              dataset_id | 1658666726768179211                                |\n",
        "|                   depth | 0                                                  |\n",
-       "|             description | test                                               |\n",
+       "|             description | Test dataset for global beacon                     |\n",
        "|         documents_count | 26312                                              |\n",
        "|                filename | beacon-test-dataset                                |\n",
        "|               full_path | solvebio:public:/beacon-test-dataset               |\n",
@@ -99,7 +99,7 @@
        "|                      id | 1658666726768179211                                |\n",
        "|              is_deleted | False                                              |\n",
        "|        is_transformable | False                                              |\n",
-       "|           last_accessed | 2022-01-12T13:04:24Z                               |\n",
+       "|           last_accessed | 2022-01-18T15:42:21Z                               |\n",
        "|           last_modified | 2021-11-29T11:27:06.214Z                           |\n",
        "|                     md5 |                                                    |\n",
        "|                metadata | {}                                                 |\n",
@@ -111,8 +111,8 @@
        "|                    path | /beacon-test-dataset                               |\n",
        "|                    size |                                                    |\n",
        "|           storage_class | Standard-IA                                        |\n",
-       "|                    tags | ['test', 'other tag']                              |\n",
-       "|              updated_at | 2022-01-13T09:59:14.268Z                           |\n",
+       "|                    tags | ['test']                                           |\n",
+       "|              updated_at | 2022-01-18T15:37:19.783Z                           |\n",
        "|              upload_url |                                                    |\n",
        "|                     url |                                                    |\n",
        "|                    user | {  \"class_name\": \"User\",  \"email\": \"nkrivacevi ... |\n",
@@ -121,7 +121,7 @@
        "|              vault_name | public                                             |"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,13 +135,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 125,\n",
+       "{'id': 136,\n",
        " 'datastore_id': 6,\n",
        " 'dataset_id': 1658666726768179211,\n",
        " 'status': 'indexing',\n",
@@ -149,7 +149,7 @@
        " 'is_deleted': False}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,13 +182,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 125,\n",
+       "{'id': 136,\n",
        " 'datastore_id': 6,\n",
        " 'dataset_id': 1658666726768179211,\n",
        " 'status': 'completed',\n",
@@ -196,7 +196,7 @@
        " 'is_deleted': False}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -229,13 +229,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 125,\n",
+       "{'id': 136,\n",
        " 'datastore_id': 6,\n",
        " 'dataset_id': 1658666726768179211,\n",
        " 'status': 'destroying',\n",
@@ -243,7 +243,7 @@
        " 'is_deleted': False}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -264,12 +264,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When Global Beacon index has been deleted on the dataset, if we try to get the Global Beacon for that dataset, we'll get `404` error with following message: `\"Error: No Global Beacon for Dataset:DATASET_ID\"`"
+    "When Global Beacon index has been deleted on the dataset, when you try to get the status for the Global Beacon it will return `None`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Getting the status of global beacon on the dataset\n",
+    "status = dataset.get_global_beacon_status()\n",
+    "print(status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you may set the argument `raise_on_disabled` to `True`, to raise an exception if Global Beacon doesn't exist on the dataset. You'll get `404` error with following message: `\"Error: No Global Beacon for Dataset:DATASET_ID\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -279,8 +305,8 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mSolveError\u001b[0m                                Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [7]\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Getting the status of global beacon on the dataset\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mdataset\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_global_beacon_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Projects/solvebio-python-3/solvebio-python/build/lib/solvebio/resource/object.py:635\u001b[0m, in \u001b[0;36mObject.get_global_beacon_status\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    632\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mis_dataset:\n\u001b[1;32m    633\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m SolveError(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOnly dataset objects can be Global Beacons.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 635\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minstance_url\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m/beacon\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m{\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Input \u001b[0;32mIn [15]\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdataset\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_global_beacon_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43mraise_on_disabled\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Projects/solvebio-python-3/solvebio-python/build/lib/solvebio/resource/object.py:632\u001b[0m, in \u001b[0;36mObject.get_global_beacon_status\u001b[0;34m(self, raise_on_disabled)\u001b[0m\n\u001b[1;32m    629\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m SolveError(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOnly dataset objects can be Global Beacons.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    631\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 632\u001b[0m     response \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minstance_url\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m/beacon\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m{\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    633\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m SolveError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    634\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m raise_on_disabled:\n",
       "File \u001b[0;32m~/Projects/solvebio-python-3/solvebio-python/build/lib/solvebio/client.py:161\u001b[0m, in \u001b[0;36mSolveClient.get\u001b[0;34m(self, url, params, **kwargs)\u001b[0m\n\u001b[1;32m    158\u001b[0m \u001b[38;5;124;03m\"\"\"Issues an HTTP GET across the wire via the Python requests\u001b[39;00m\n\u001b[1;32m    159\u001b[0m \u001b[38;5;124;03mlibrary. See *request()* for information on keyword args.\"\"\"\u001b[39;00m\n\u001b[1;32m    160\u001b[0m kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mparams\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m params\n\u001b[0;32m--> 161\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrequest\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mGET\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/Projects/solvebio-python-3/solvebio-python/build/lib/solvebio/client.py:263\u001b[0m, in \u001b[0;36mSolveClient.request\u001b[0;34m(self, method, url, **kwargs)\u001b[0m\n\u001b[1;32m    260\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrequest(method, url, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    262\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;241m200\u001b[39m \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m response\u001b[38;5;241m.\u001b[39mstatus_code \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m400\u001b[39m):\n\u001b[0;32m--> 263\u001b[0m     \u001b[43m_handle_api_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    265\u001b[0m \u001b[38;5;66;03m# 204 is used on deletion. There is no JSON here.\u001b[39;00m\n\u001b[1;32m    266\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m raw \u001b[38;5;129;01mor\u001b[39;00m response\u001b[38;5;241m.\u001b[39mstatus_code \u001b[38;5;129;01min\u001b[39;00m [\u001b[38;5;241m204\u001b[39m, \u001b[38;5;241m301\u001b[39m, \u001b[38;5;241m302\u001b[39m]:\n",
       "File \u001b[0;32m~/Projects/solvebio-python-3/solvebio-python/build/lib/solvebio/client.py:42\u001b[0m, in \u001b[0;36m_handle_api_error\u001b[0;34m(response)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m response\u001b[38;5;241m.\u001b[39mstatus_code \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m [\u001b[38;5;241m400\u001b[39m, \u001b[38;5;241m401\u001b[39m, \u001b[38;5;241m403\u001b[39m, \u001b[38;5;241m404\u001b[39m]:\n\u001b[1;32m     41\u001b[0m     logger\u001b[38;5;241m.\u001b[39minfo(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mAPI Error: \u001b[39m\u001b[38;5;132;01m%d\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m%\u001b[39m response\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[0;32m---> 42\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m SolveError(response\u001b[38;5;241m=\u001b[39mresponse)\n",
@@ -289,16 +315,8 @@
     }
    ],
    "source": [
-    "# Getting the status of global beacon on the dataset\n",
-    "dataset.get_global_beacon_status()"
+    "dataset.get_global_beacon_status(raise_on_disabled=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/global_search.ipynb
+++ b/examples/global_search.ipynb
@@ -400,7 +400,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the searches where `entities` parameter was used, we can also retrieve the `list of subjects`, otherwise None is returned."
+    "We can also retrieve the `list of subjects`:"
    ]
   },
   {

--- a/solvebio/cli/ipython_init.py
+++ b/solvebio/cli/ipython_init.py
@@ -28,6 +28,10 @@ from solvebio import Task  # noqa
 from solvebio import VaultSyncTask  # noqa
 from solvebio import ObjectCopyTask  # noqa
 from solvebio import SavedQuery  # noqa
+from solvebio import DatasetRestoreTask  # noqa
+from solvebio import DatasetSnapshotTask  # noqa
+from solvebio import GlobalSearch  # noqa
+from solvebio import Group  # noqa
 from solvebio.utils.printing import pager  # noqa
 
 # Add some convenience functions to the interactive shell

--- a/solvebio/global_search.py
+++ b/solvebio/global_search.py
@@ -159,7 +159,7 @@ class GlobalSearch(Query):
 
     def execute(self, offset=0, **query):
         # Call superclass method execute
-        Query.execute(self, offset, **query)
+        super(GlobalSearch, self).execute(offset, **query)
 
         # Cast logical objects from response to Object/Vault instances
         if not self._raw_results:
@@ -193,6 +193,6 @@ class GlobalSearch(Query):
         """If entity seaarch is performed returns the list of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
-        self.execute(include_subjects=True, limit=0)
+        self.execute(limit=0)
 
         return self._response.get('subjects_count')

--- a/solvebio/global_search.py
+++ b/solvebio/global_search.py
@@ -107,7 +107,7 @@ class GlobalSearch(Query):
         if filters:
             new._filters += filters
 
-        if limit:
+        if limit is not None:
             new._limit = limit
 
         return new
@@ -185,14 +185,16 @@ class GlobalSearch(Query):
         """Returns the list of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
-        self.execute(include_subjects=True, limit=0)
+        gs = self.limit(0)
+        gs.execute(include_subjects=True)
 
-        return self._response.get('subjects')
+        return gs._response.get('subjects')
 
     def subjects_count(self):
         """Returns the number of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
-        self.execute(limit=0)
+        gs = self.limit(0)
+        gs.execute()
 
-        return self._response.get('subjects_count')
+        return gs._response.get('subjects_count')

--- a/solvebio/global_search.py
+++ b/solvebio/global_search.py
@@ -182,7 +182,7 @@ class GlobalSearch(Query):
         return self._clone(entities=list(kwargs.items()))
 
     def subjects(self):
-        """If entity seaarch is performed returns the list of subjects"""
+        """Returns the list of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
         self.execute(include_subjects=True, limit=0)
@@ -190,7 +190,7 @@ class GlobalSearch(Query):
         return self._response.get('subjects')
 
     def subjects_count(self):
-        """If entity seaarch is performed returns the list of subjects"""
+        """Returns the number of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
         self.execute(limit=0)

--- a/solvebio/global_search.py
+++ b/solvebio/global_search.py
@@ -185,7 +185,7 @@ class GlobalSearch(Query):
         """If entity seaarch is performed returns the list of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
-        self.execute()
+        self.execute(include_subjects=True, limit=0)
 
         return self._response.get('subjects')
 
@@ -193,6 +193,6 @@ class GlobalSearch(Query):
         """If entity seaarch is performed returns the list of subjects"""
 
         # Executes a query to get a full API response which contains subjects list
-        self.execute()
+        self.execute(include_subjects=True, limit=0)
 
         return self._response.get('subjects_count')

--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -630,7 +630,7 @@ class Query(QueryBase):
         if filters:
             new._filters += filters
 
-        if limit:
+        if limit is not None:
             new._limit = limit
 
         return new
@@ -1144,7 +1144,7 @@ class QueryFile(QueryBase):
         if filters:
             new._filters += filters
 
-        if limit:
+        if limit is not None:
             new._limit = limit
 
         return new

--- a/solvebio/resource/dataset.py
+++ b/solvebio/resource/dataset.py
@@ -317,3 +317,21 @@ class Dataset(CreateableAPIResource,
     def vault_object(self):
         from solvebio import Object
         return Object.retrieve(self['vault_object_id'], client=self._client)
+
+    def enable_global_beacon(self):
+        """
+        Enable Global Beacon for this dataset.
+        """
+        return self.vault_object.enable_global_beacon()
+
+    def disable_global_beacon(self):
+        """
+        Disable Global Beacon for this dataset.
+        """
+        return self.vault_object.disable_global_beacon()
+
+    def get_global_beacon_status(self, raise_on_disabled=False):
+        """
+        Retrieves the Global Beacon status for this dataset.
+        """
+        return self.vault_object.get_global_beacon_status(raise_on_disabled)

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -629,11 +629,8 @@ class Object(CreateableAPIResource,
             raise SolveError("Only dataset objects can be Global Beacons.")
 
         try:
-            response = self._client.get(self.instance_url() + '/beacon', {})
+            return self._client.get(self.instance_url() + '/beacon', {})
         except SolveError:
-            if not raise_on_disabled:
-                response = None
-            else:
+            if raise_on_disabled:
                 raise
-
-        return response
+            return None

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -630,7 +630,7 @@ class Object(CreateableAPIResource,
 
         try:
             response = self._client.get(self.instance_url() + '/beacon', {})
-        except SolveError as e:
+        except SolveError:
             if not raise_on_disabled:
                 response = None
             else:

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -621,11 +621,19 @@ class Object(CreateableAPIResource,
 
         return self._client.delete(self.instance_url() + '/beacon', {})
 
-    def get_global_beacon_status(self):
+    def get_global_beacon_status(self, raise_on_disabled=False):
         """
         Retrieves the Global Beacon status for this object (datasets only).
         """
         if not self.is_dataset:
             raise SolveError("Only dataset objects can be Global Beacons.")
 
-        return self._client.get(self.instance_url() + '/beacon', {})
+        try:
+            response = self._client.get(self.instance_url() + '/beacon', {})
+        except SolveError as e:
+            if not raise_on_disabled:
+                response = None
+            else:
+                raise
+
+        return response


### PR DESCRIPTION
## Description

- Return None by default if dataset doesn't contain Global Beacon:

  Updated `Object.get_global_beacon_status` method so it returns `None` by default if Global Beacon doesn't exist.

  ```python
  dataset = Object.get_by_full_path(dataset_full_path)

  # Returns None
  dataset.get_global_beacon_status()

  # Raises exception: API error 404 {"detail": "No Global Beacon for Dataset:12345679"} 
  dataset.get_global_beacon_status(raise_on_disabled=True)
  ```
- Alias methods in the Dataset class for Global Beacons:
  
  Add ability to perform Global Beacon operations with the `Dataset` class:

  ```python
  dataset = Dataset.get_by_full_path(dataset_full_path)
  dataset.get_global_beacon_status()
  dataset.enable_global_beacon()
  dataset.disable_global_beacon()
  ```
 
- Subject method changes to accommodate API changes:
  
  In `subjects()`/`subjects_count()` methods adding additional parameters in the api request `limit=0` and `include_subjects=True`