### PR TITLE
BDSIM-411: Implement uploads in parallel via CLI

### DIFF
--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -251,18 +251,6 @@ def _create_file_job(args):
         raise e
     except Exception as e:
         return e
-            if dry_run:
-                print(
-                    "[Dry Run] Uploading {} to {}".format(
-                        local_file_path, remote_folder_full_path
-                    )
-                )
-            else:
-                remote_parent = Object.get_by_full_path(
-                    remote_folder_full_path, assert_type="folder"
-                )
-                Object.upload_file(local_file_path, remote_parent.path,
-                                    vault.full_path, archive_folder=archive_folder)
 
 
 def _create_template_from_file(template_file, dry_run=False):

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -28,8 +28,6 @@ from solvebio.errors import SolveError
 from solvebio.errors import NotFoundError
 
 
-
-
 def should_exclude(path, exclude_paths, dry_run=False, print_logs=True):
     if not exclude_paths:
         return False

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -109,7 +109,7 @@ def _check_uploaded_folders(base_remote_path, local_start, all_folders):
     Args:
         base_remote_path: Base remote parent folder full path to upload to.
         local_start: The name of the base folder to upload.
-        all_folders: A list of remote folders to potentially create in full path format
+        all_folders: A list of remote folders to potentially create in full path format.
     Returns:
         all_folder_parts (set): A unique set of folder parts to create that do
             not already exist.
@@ -230,16 +230,16 @@ def _create_file_job(args):
     Args:
         args[0] (local_file_path): Path to local file.
         args[1] (remote_folder_path): Path to remote parent folder.
-        args[2] (vault_path): Path to remote vault
-        args[3] (dry_run): Whether to performa dry run
+        args[2] (vault_path): Path to remote vault.
+        args[3] (dry_run): Whether to performa dry run.
     Returns:
-        None or Exception if exception is raised
+        None or Exception if exception is raised.
     """
     try:
         local_file_path, remote_folder_full_path, vault_path, dry_run = args
         if dry_run:
             print("[Dry Run] Uploading {} to {}".format(
-                    local_file_path, remote_folder_full_path))
+                local_file_path, remote_folder_full_path))
             return
         remote_parent = Object.get_by_full_path(
             remote_folder_full_path, assert_type="folder"

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -64,8 +64,6 @@ def _create_folder(vault, full_path, tags=None):
     return new_obj
 
 
-
-
 def should_exclude(path, exclude_paths, dry_run=False, print_logs=True):
     if not exclude_paths:
         return False
@@ -126,7 +124,6 @@ def _upload_folder(
         else:
             all_folders.append((vault, base_folder_path))
 
-
     # Create folders and upload files
     for abs_local_parent_path, folders, files in os.walk(base_local_path):
         # Strips off the local path and adds the parent directory at
@@ -167,7 +164,6 @@ def _upload_folder(
             else:
                 all_files.append((local_file_path, remote_folder_full_path, vault.full_path))
 
-
     # Identify which remote folders already exist
     upload_root_path, _ = Object.validate_full_path(
         os.path.join(base_remote_path, local_start)
@@ -183,7 +179,6 @@ def _upload_folder(
             if folder_full_path not in remote_folders_existing and not folder_full_path.endswith(":"):
                 all_folder_parts.add(folder_full_path)
             parent_folder_path = folder_full_path
-
 
     if not dry_run:
         # Create folders serially since these require

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -232,6 +232,14 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     "default": "~/",
                 },
                 {
+                    "flags": "--num-processes",
+                    "help": "Number of uploads to process in parallel. Defaults "
+                    "to 1, but can be set much higher than CPU count since the "
+                    "upload process is IO bound, not CPU bound.",
+                    "default": 1,
+                    "type": int
+                },
+                {
                     "flags": "--create-full-path",
                     "help": "Creates --full-path location if it does "
                     "not exist. NOTE: This will not create new vaults.",

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -297,6 +297,9 @@ class Object(CreateableAPIResource,
         mimetype = mime_tuple[1] if mime_tuple[1] else mime_tuple[0]
         # Get file size
         size = os.path.getsize(local_path)
+        if size == 0:
+            print('WARNING: skipping empty object: {}'.format(local_path))
+            return False
 
         # Check if object exists already and compare md5sums
         full_path, path_dict = Object.validate_full_path(

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -284,8 +284,6 @@ class Object(CreateableAPIResource,
         return datetime.now().strftime(date_format)
 
     def _archive(self, archive_folder):
-        from solvebio.cli.data import _create_folder
-
         if not self.object_type == "file":
             raise NotImplementedError("Object archiving is only supported for files, not {}".format(self.object_type))
 
@@ -312,7 +310,7 @@ class Object(CreateableAPIResource,
             parent_folder_path = self.vault.full_path + ":"
             for folder in folders:
                 folder_full_path = os.path.join(parent_folder_path, folder)
-                parent_folder = _create_folder(self.vault, folder_full_path)
+                parent_folder = Object.create_folder(self.vault, folder_full_path)
                 parent_folder_path = parent_folder.full_path
             self.parent_object_id = parent_folder.id
         else:
@@ -324,6 +322,59 @@ class Object(CreateableAPIResource,
         self.save()
         self.filename = archive_filename
         return self.save()
+
+    @classmethod
+    def create_folder(cls, vault, full_path, tags=None, **kwargs):
+        """Create a folder if not exists.
+
+        Args:
+            vault (Vault): A Vault object.
+            full_path (str): Full path including vault name.
+            tags (list[str]): List of tags to put on folder.
+            client: SolveBio client configuration to use.
+        Returns:
+            Object: New folder object
+        Raises:
+            SolveError: if a file or dataset object already exists
+                at the given full_path.
+        """
+        _client = kwargs.pop('client', None) or cls._client or client
+
+        full_path, path_dict = Object.validate_full_path(full_path, client=client)
+        folder_name = path_dict["filename"]
+
+        try:
+            new_obj = Object.get_by_full_path(full_path, client=client)
+            if not new_obj.is_folder:
+                raise SolveError(
+                    "Object type {} already exists at location: {}".format(
+                        new_obj.object_type, full_path
+                    )
+                )
+        except NotFoundError:
+            # Create the folder
+            if path_dict["parent_path"] == "/":
+                parent_object_id = None
+            else:
+                parent = Object.get_by_full_path(
+                    path_dict["parent_full_path"], assert_type="folder", client=client
+                )
+                parent_object_id = parent.id
+
+            # Make the API call
+            new_obj = Object.create(
+                vault_id=vault.id,
+                parent_object_id=parent_object_id,
+                object_type="folder",
+                filename=folder_name,
+                tags=tags or [],
+                client=client
+            )
+
+            print("Notice: Folder created for {0} at {1}".format(folder_name, new_obj.path))
+
+        return new_obj
+
 
     @classmethod
     def upload_file(cls, local_path, remote_path, vault_full_path, **kwargs):

--- a/solvebio/resource/object.py
+++ b/solvebio/resource/object.py
@@ -340,11 +340,11 @@ class Object(CreateableAPIResource,
         """
         _client = kwargs.pop('client', None) or cls._client or client
 
-        full_path, path_dict = Object.validate_full_path(full_path, client=client)
+        full_path, path_dict = Object.validate_full_path(full_path, client=_client)
         folder_name = path_dict["filename"]
 
         try:
-            new_obj = Object.get_by_full_path(full_path, client=client)
+            new_obj = Object.get_by_full_path(full_path, client=_client)
             if not new_obj.is_folder:
                 raise SolveError(
                     "Object type {} already exists at location: {}".format(
@@ -357,7 +357,7 @@ class Object(CreateableAPIResource,
                 parent_object_id = None
             else:
                 parent = Object.get_by_full_path(
-                    path_dict["parent_full_path"], assert_type="folder", client=client
+                    path_dict["parent_full_path"], assert_type="folder", client=_client
                 )
                 parent_object_id = parent.id
 
@@ -368,13 +368,12 @@ class Object(CreateableAPIResource,
                 object_type="folder",
                 filename=folder_name,
                 tags=tags or [],
-                client=client
+                client=_client
             )
 
             print("Notice: Folder created for {0} at {1}".format(folder_name, new_obj.path))
 
         return new_obj
-
 
     @classmethod
     def upload_file(cls, local_path, remote_path, vault_full_path, **kwargs):

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -11,6 +11,7 @@ from .helper import SolveBioTestCase
 from solvebio.test.client_mocks import fake_object_create, fake_object_save
 from solvebio.test.client_mocks import fake_dataset_create
 
+
 def get_uuid_str():
     return str(uuid.uuid4())
 

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -328,12 +328,14 @@ class ObjectUploadTests(SolveBioTestCase):
         if not os.path.exists(self.tempdir):
             os.makedirs(self.tempdir)
 
+        # Do not delete vault at end of
+        # test as other tests run in
+        # parallel and may expect files
         vault_name = "ObjectUploadTests"
         self.vault = self.client.Vault.get_or_create_by_full_path(vault_name)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
-        self.vault.delete(force=True)
 
     @mock.patch('solvebio.resource.Dataset.create')
     @mock.patch('solvebio.resource.Object.create')

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -11,6 +11,9 @@ from .helper import SolveBioTestCase
 from solvebio.test.client_mocks import fake_object_create, fake_object_save
 from solvebio.test.client_mocks import fake_dataset_create
 
+def get_uuid_str():
+    return str(uuid.uuid4())
+
 
 class ObjectTests(SolveBioTestCase):
 
@@ -325,7 +328,8 @@ class ObjectUploadTests(SolveBioTestCase):
         if not os.path.exists(self.tempdir):
             os.makedirs(self.tempdir)
 
-        self.vault = self.client.Vault.create(name=str(uuid.uuid4()))
+        vault_name = "ObjectUploadTests"
+        self.vault = self.client.Vault.get_or_create_by_full_path(vault_name)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -346,13 +350,13 @@ class ObjectUploadTests(SolveBioTestCase):
             dataset_object._archive('archive_folder')
 
     def test_create_folder(self):
-        folder_full_path = self.vault.full_path + ":/test-folder"
+        folder_full_path = self.vault.full_path + ":/{}-test-folder".format(get_uuid_str())
         self.client.Object.create_folder(self.vault, folder_full_path)
         obj = self.client.Object.get_by_full_path(folder_full_path)
         self.assertEqual(obj.object_type, 'folder')
 
     def test_upload_file(self):
-        local_path = os.path.join(self.tempdir, "file.txt")
+        local_path = os.path.join(self.tempdir, "{}-file.txt".format(get_uuid_str()))
         with open(local_path, "w") as fp:
             fp.write("sample file")
         remote_path = "/"
@@ -368,7 +372,7 @@ class ObjectUploadTests(SolveBioTestCase):
         self.assertEqual(response.content.decode('utf-8'), "sample file")
 
     def test_skip_md5_match(self):
-        local_path = os.path.join(self.tempdir, "file.txt")
+        local_path = os.path.join(self.tempdir, "{}-file.txt".format(get_uuid_str()))
         with open(local_path, "w") as fp:
             fp.write("sample file")
         remote_path = "/"
@@ -380,7 +384,9 @@ class ObjectUploadTests(SolveBioTestCase):
 
     @mock.patch('solvebio.resource.object.Object._get_timestamp')
     def test_archive_if_updated(self, TimeStamp):
-        local_path = os.path.join(self.tempdir, "file.txt.gz")
+        filename = "{}-file.txt.gz".format(get_uuid_str())
+        filename_base = filename.split(".")[0]
+        local_path = os.path.join(self.tempdir, filename)
         with open(local_path, "w") as fp:
             fp.write("sample file")
         remote_path = "/"
@@ -397,13 +403,13 @@ class ObjectUploadTests(SolveBioTestCase):
         dir_object = self.client.Object.get_by_full_path(expected_archive_dir)
         self.assertEqual(dir_object.object_type, 'folder')
 
-        expected_archive_full_path = self.vault.full_path + ":/archive/file_timestamp_string.txt.gz"
+        expected_archive_full_path = self.vault.full_path + ":/archive/{}_timestamp_string.txt.gz".format(filename_base)
         archive_obj = self.client.Object.get_by_full_path(expected_archive_full_path)
         download_url = archive_obj.download_url()
         response = requests.request(method='get', url=download_url)
         self.assertEqual(response.content.decode('utf-8'), "sample file")
 
-        expected_new_path = self.vault.full_path + ":/file.txt.gz"
+        expected_new_path = self.vault.full_path + ":/" + filename
         new_obj = self.client.Object.get_by_full_path(expected_new_path)
         download_url = new_obj.download_url()
         response = requests.request(method='get', url=download_url)

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -347,10 +347,9 @@ class ObjectUploadTests(SolveBioTestCase):
 
     def test_create_folder(self):
         folder_full_path = self.vault.full_path + ":/test-folder"
-        folder_obj = self.client.Object.create_folder(self.vault, folder_full_path)
+        self.client.Object.create_folder(self.vault, folder_full_path)
         obj = self.client.Object.get_by_full_path(folder_full_path)
         self.assertEqual(obj.object_type, 'folder')
-
 
     def test_upload_file(self):
         local_path = os.path.join(self.tempdir, "file.txt")

--- a/solvebio/test/test_object.py
+++ b/solvebio/test/test_object.py
@@ -345,6 +345,13 @@ class ObjectUploadTests(SolveBioTestCase):
         with self.assertRaises(NotImplementedError):
             dataset_object._archive('archive_folder')
 
+    def test_create_folder(self):
+        folder_full_path = self.vault.full_path + ":/test-folder"
+        folder_obj = self.client.Object.create_folder(self.vault, folder_full_path)
+        obj = self.client.Object.get_by_full_path(folder_full_path)
+        self.assertEqual(obj.object_type, 'folder')
+
+
     def test_upload_file(self):
         local_path = os.path.join(self.tempdir, "file.txt")
         with open(local_path, "w") as fp:

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -288,15 +288,18 @@ class ImportTests(CLITests):
 
 
 class UploadTests(CLITests):
+
     @mock.patch("solvebio.resource.apiresource.ListableAPIResource._retrieve_helper")
     @mock.patch("solvebio.resource.Vault.get_by_full_path")
     @mock.patch("solvebio.resource.Vault.all")
     @mock.patch("solvebio.resource.Object.all")
     @mock.patch("solvebio.resource.Object.create")
     @mock.patch("solvebio.resource.Object.upload_file")
+    @mock.patch("solvebio.global_search.GlobalSearch.filter")
     def _test_upload_command(
         self,
         args,
+        GlobalSearch,
         ObjectUpload,
         ObjectCreate,
         ObjectAll,
@@ -306,6 +309,7 @@ class UploadTests(CLITests):
         **kwargs
     ):
 
+        GlobalSearch.side_effect = fake_object_all
         ObjectUpload.side_effect = fake_object_create
         ObjectAll.side_effect = fake_object_all
         ObjectCreate.side_effect = fake_object_create

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -368,6 +368,18 @@ class UploadTests(CLITests):
         ]
         self._test_upload_command(args)
 
+        # Test multiprocess
+        args = [
+            "upload",
+            "--num-processes",
+            "2",
+            "--full-path",
+            "solvebio:test_vault:/test-folder-upload",
+            folder_,
+        ]
+        with self.assertRaises(NotFoundError):
+            self._test_upload_command(args, fail_lookup=True)
+
     @mock.patch("solvebio.resource.apiresource.ListableAPIResource._retrieve_helper")
     @mock.patch("solvebio.resource.Object.all")
     @mock.patch("solvebio.resource.Object.create")

--- a/solvebio/test/test_shortcuts.py
+++ b/solvebio/test/test_shortcuts.py
@@ -13,8 +13,8 @@ import solvebio
 from solvebio.cli import main
 from solvebio import DatasetTemplate
 from solvebio import Vault
+from solvebio.resource.object import Object
 from solvebio.errors import NotFoundError
-from solvebio.cli.data import _create_folder
 from solvebio.cli.data import should_exclude
 from solvebio.test.client_mocks import fake_vault_all
 from solvebio.test.client_mocks import fake_vault_create
@@ -384,7 +384,7 @@ class UploadTests(CLITests):
 
         RetrieveHelper.side_effect = fake_object_retrieve
         full_path = vault.full_path + ":/new_folder"
-        f = _create_folder(vault, full_path)
+        f = Object.create_folder(vault, full_path)
         self.assertEqual(f.full_path, full_path)
 
     def test_should_exclude(self):


### PR DESCRIPTION
Ticket: https://precisionformedicine.atlassian.net/browse/BDSIM-411

Current uploads can be really slow if there are thousands of files to upload. Most of this time is IO bound waiting for API requests so we can implement some degree of parallelization. This implementation strategy allows users to specify the number of parallel processes via a CLI option (`--num-processes`).

This implementation _should_ preserve all original functionality by default and will only perform multiprocessing uploads if users specify a flag. Otherwise, uploads will still happen in a multiprocessing.Pool, but with only 1 parallel process.