### PR TITLE
Allow silent uploads

### DIFF
--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -720,13 +720,14 @@ def ls(args):
     """
     Given a SolveBio remote path, list the files and folders
     """
-    return _ls(args.full_path)
+    return _ls(args.full_path, silent=args.silent)
 
 
-def _ls(full_path):
+def _ls(full_path, silent=False):
 
     if "**" in full_path:
-        print("Recursive paths containing ** are not supported by `ls`")
+        if not silent:
+            print("Recursive paths containing ** are not supported by `ls`")
         return
 
     files = list(Object.all(glob=full_path, limit=1000))
@@ -740,10 +741,11 @@ def _ls(full_path):
         )
 
     if len(files) == 0:
-        print(
-            "No file(s) found at --full-path {}, "
-            'try using a glob instead:  "vault:/path/folder/*'.format(full_path)
-        )
+        if not silent:
+            print(
+                "No file(s) found at --full-path {}, "
+                'try using a glob instead:  "vault:/path/folder/*'.format(full_path)
+            )
 
 
 def should_tag_by_object_type(args, object_):

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -284,6 +284,12 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     "action": TildeFixStoreAction,
                     "default": "~/",
                 },
+                {
+                    "flags": "--silent",
+                    "help": "Only print found files, without any warnings "
+                    "or hints. Useful when used programatically.",
+                    "action": "store_true",
+                },
             ],
         },
         "download": {


### PR DESCRIPTION
In the Makefiles, the following command is often used:

```
LAST_EDC_UPLOAD=$$(solvebio ls $(EDP_VAULT):/$(DEVMODE)/$(PROJECT)/data/source/vSIM_EDC/ | sort | uniq | tail -1 | awk '{print $$2}'; ) ; \
```

Here, if no files are found, the previous behaviour was to print a help text. However, this interferes with the downstream logic. This PR introduces a `--silent` option to this function so that no help texts are printed.