### PR TITLE
[EDPDEV-1000] Fix upload bug

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ pyyaml==5.3.1
 click==7.1.2
 ruamel.yaml==0.16.12
 pytest
+brotli<=1.0.9

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if sys.version_info < (2, 6):
     install_requires.append('requests >= 0.8.8, < 0.10.1')
     install_requires.append('ssl')
 elif sys.version_info < (2, 7):
+    install_requires.append('brotli==1.0.9')
     install_requires.append('ordereddict')
 else:
     install_requires.append('requests>=2.0.0')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ if sys.version_info < (2, 6):
     install_requires.append('requests >= 0.8.8, < 0.10.1')
     install_requires.append('ssl')
 elif sys.version_info < (2, 7):
-    install_requires.append('brotli==1.0.9')
     install_requires.append('ordereddict')
 else:
     install_requires.append('requests>=2.0.0')

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -207,14 +207,17 @@ def _create_file_job(args):
             return
         client = SolveClient()
         remote_parent = Object.get_by_full_path(
-            remote_folder_full_path, assert_type="folder", debug=True,
+            remote_folder_full_path,
+            assert_type="folder",
             client=client
         )
-        Object.upload_file(local_file_path,
-                           remote_parent.path,
-                           vault_path,
-                           archive_folder=archive_folder,
-                           client=client)
+        Object.upload_file(
+            local_file_path,
+            remote_parent.path,
+            vault_path,
+            archive_folder=archive_folder,
+            client=client
+        )
         return
     except KeyboardInterrupt as e:
         raise e

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -26,6 +26,7 @@ from solvebio.utils.files import check_gzip_path
 from solvebio.utils.md5sum import md5sum
 from solvebio.errors import SolveError
 from solvebio.errors import NotFoundError
+from solvebio.client import SolveClient
 
 
 def should_exclude(path, exclude_paths, dry_run=False, print_logs=True):
@@ -155,14 +156,11 @@ def _upload_folder(
                 continue
             all_files.append((local_file_path, remote_folder_full_path, vault.full_path, dry_run, archive_folder))
 
-    all_folder_parts = set([x[1] for x in all_folders])
-    """  # TODO: need more investigation about GlobalSearch API results, below code does not working with api results
     if num_processes > 1:
         # Only perform optimization if parallelization is requested by the user
         all_folder_parts = _check_uploaded_folders(base_remote_path, local_start, all_folders)
     else:
         all_folder_parts = set([x[1] for x in all_folders])
-    """
     # Create folders serially since these require
     # previous folders to be created so that parent_object_id can
     # be populated
@@ -207,10 +205,16 @@ def _create_file_job(args):
             print("[Dry Run] Uploading {} to {}".format(
                 local_file_path, remote_folder_full_path))
             return
+        client = SolveClient()
         remote_parent = Object.get_by_full_path(
-            remote_folder_full_path, assert_type="folder"
+            remote_folder_full_path, assert_type="folder", debug=True,
+            client=client
         )
-        Object.upload_file(local_file_path, remote_parent.path, vault_path, archive_folder=archive_folder)
+        Object.upload_file(local_file_path,
+                           remote_parent.path,
+                           vault_path,
+                           archive_folder=archive_folder,
+                           client=client)
         return
     except KeyboardInterrupt as e:
         raise e


### PR DESCRIPTION
The issue was related to the session object not being thread-safe. Previously, a single session object was shared across all processes making requests leading to really strange errors (e.g. ECONNRESET). 

This change creates a new session object for each process. I have tested this by running the following command to upload ~1000 files to an EDP instance:


```
solvebio upload --full-path "edp:Nishanth's Test Vault:/folder" ./source --num-processes 20 --create-full-path
```

Previously, this would fail immediately after creating the folders. Now, this entire process succeeds.
