### PR TITLE
[EDPDEV-1075] Update env var token names

### DIFF
--- a/solvebio/__init__.py
+++ b/solvebio/__init__.py
@@ -26,7 +26,12 @@ except:
 api_key = _os.environ.get('SOLVEBIO_API_KEY', None)
 # OAuth2 access tokens
 access_token = _os.environ.get('SOLVEBIO_ACCESS_TOKEN', None)
-api_host = _os.environ.get('SOLVEBIO_API_HOST', 'https://api.solvebio.com')
+if access_token is None:
+    access_token = _os.environ.get('EDP_ACCESS_TOKEN', None)
+
+api_host = _os.environ.get('SOLVEBIO_API_HOST', None)
+if api_host is None:
+    api_host = _os.environ.get('EDP_API_HOST', 'https://api.solvebio.com')
 
 
 def help():


### PR DESCRIPTION
@davecap the new R client expects to find access tokens and credentials at `EDP_ACCESS_TOKEN` and `EDP_API_HOST` respectively. What do you think about adding this as a backup for this client?

This was also causing our vsim docker image to fail: https://precisionformedicine.atlassian.net/browse/EDPDEV-1075?focusedCommentId=155033