### PR TITLE
Add Connect to Client Retry Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For all other requests, please [email SolveBio Support](mailto:support@solvebio.
 Configuring the Client
 -------
 
-The Solvebio python client can be configured by setting system environment variables.
+The SolveBio python client can be configured by setting system environment variables.
 Supported environment variables are:
 
 `SOLVEBIO_API_HOST`     

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ The Solvebio python client can be configured by setting system environment varia
 Supported environment variables are:
 
 `SOLVEBIO_API_HOST`     
-- The URL of the target API backend.
-                          If not specified the value from the local credentials file will be used.
+- The URL of the target API backend. 
+If not specified the value from the local credentials file will be used.
 
 `SOLVEBIO_ACCESS_TOKEN` 
 - The OAuth2 access token for authenticating with the API.
@@ -100,7 +100,7 @@ The lookup order for credentials is:
 
 `SOLVEBIO_LOGLEVEL` 
 - The log level at which to log messages.
-                          If not specified the default log level will be WARN.
+If not specified the default log level will be WARN.
 
 `SOLVEBIO_LOGFILE`        
 - The file in which to write log messages. 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,41 @@ Developer documentation is available at [docs.solvebio.com](https://docs.solvebi
 If you experience problems with this package, please [create a GitHub Issue](https://github.com/solvebio/solvebio-python/issues).
 
 For all other requests, please [email SolveBio Support](mailto:support@solvebio.com).
+
+
+Configuring the Client
+-------
+
+The Solvebio python client can be configured by setting system environment variables.
+Supported environment variables are:
+
+`SOLVEBIO_API_HOST`     
+- The URL of the target API backend.
+                          If not specified the value from the local credentials file will be used.
+
+`SOLVEBIO_ACCESS_TOKEN` 
+- The OAuth2 access token for authenticating with the API.
+
+`SOLVEBIO_API_KEY`       
+- The API Key to use for authenticating with the API.
+
+The lookup order for credentials is:
+1. Access Token
+2. API Key
+3. Local Credentials file
+
+`SOLVEBIO_LOGLEVEL` 
+- The log level at which to log messages.
+                          If not specified the default log level will be WARN.
+
+`SOLVEBIO_LOGFILE`        
+- The file in which to write log messages. 
+If the file does not exist it will be created. 
+If not specified '~/.solvebio/solvebio.log' will be used by default.
+
+`SOLEVBIO_RETRY_ALL`      
+- Flag for enabling aggressive retries for failed requests to the API.
+When truthy, the client will attempt to retry a failed request regardless of the type of operation.
+This includes idempotent and nonidempotent operations:
+"HEAD", "GET", "PUT", "POST", "PATCH", "DELETE", "OPTIONS", "TRACE"
+If this value is not set it will default to false and retries will only be enabled for idempotent operations.

--- a/solvebio/client.py
+++ b/solvebio/client.py
@@ -107,6 +107,7 @@ class SolveClient(object):
         # intermittent connection errors.
         retries = Retry(
             total=5,
+            connect=5,
             backoff_factor=0.1,
             status_forcelist=[
                 codes.bad_gateway,

--- a/solvebio/client.py
+++ b/solvebio/client.py
@@ -105,8 +105,8 @@ class SolveClient(object):
         self.set_user_agent()
 
         solvebio_retry_all = os.environ.get('SOLVEBIO_RETRY_ALL')
-        if solvebio_retry_all == '1':
-            logger.info("Retries enabled for all operations.")
+        if bool(solvebio_retry_all):
+            logger.info("Retries enabled for all API requests")
             allowed_methods = frozenset([
                 "HEAD",
                 "GET",
@@ -118,7 +118,7 @@ class SolveClient(object):
                 "TRACE"
             ])
         else:
-            logger.info("Retries enabled only for idempotent operations.")
+            logger.info("Retries enabled for read-only API requests")
             allowed_methods = frozenset([
                 "HEAD",
                 "GET",
@@ -130,7 +130,7 @@ class SolveClient(object):
         # intermittent connection errors.
         retries = Retry(
             total=5,
-            backoff_factor=0.1,
+            backoff_factor=2,
             status_forcelist=[
                 codes.bad_gateway,
                 codes.service_unavailable,

--- a/solvebio/client.py
+++ b/solvebio/client.py
@@ -113,7 +113,17 @@ class SolveClient(object):
                 codes.bad_gateway,
                 codes.service_unavailable,
                 codes.gateway_timeout
+            ],
+            allowed_methods=frozenset([
+                "HEAD",
+                "GET",
+                "PUT",
+                "POST",
+                "DELETE",
+                "OPTIONS",
+                "TRACE"
             ])
+        )
         adapter = HTTPAdapter(max_retries=retries)
         self._session = Session()
         self._session.mount(self._host, adapter)


### PR DESCRIPTION
This PR sets the connect parameter to the session Retry.
As per the documentation this should enable retries on dropped connections.
Linked ticket:
https://precisionformedicine.atlassian.net/browse/EDPDEV-1175

And added an explicit list of allowed methods.
This includes non-idempotent request - however imo if the retries only occur on 502 503 504 or a not established connection this should not cause an issue.