### PR TITLE
Add --follow-shortcuts to ls Command

### DIFF
--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -956,7 +956,7 @@ def ls(args):
     return True
 
 
-def _ls(full_path, recursive=False, follow_shortcuts=False):        
+def _ls(full_path, recursive=False, follow_shortcuts=False):
     files = list(Object.all(glob=full_path, limit=1000))
 
     for file_ in files:
@@ -966,7 +966,10 @@ def _ls(full_path, recursive=False, follow_shortcuts=False):
                 resolved_file = file_.get_target()
                 print(
                     "{}  {}  {}  from shortcut: {}".format(
-                        resolved_file.last_modified, resolved_file.object_type.ljust(8), resolved_file.full_path.ljust(50), shortcut
+                        resolved_file.last_modified,
+                        resolved_file.object_type.ljust(8),
+                        resolved_file.full_path.ljust(50),
+                        shortcut
                     )
                 )
             except NotFoundError:

--- a/solvebio/cli/data.py
+++ b/solvebio/cli/data.py
@@ -942,9 +942,7 @@ def ls(args):
               "Try the --recursive flag instead.")
         return False
 
-    follow_shortcuts = True if args.follow_shortcuts else False
-
-    files = _ls(args.full_path, recursive=args.recursive, follow_shortcuts=follow_shortcuts)
+    files = _ls(args.full_path, recursive=args.recursive, follow_shortcuts=args.follow_shortcuts)
 
     if len(files) == 0:
         print(
@@ -974,9 +972,8 @@ def _ls(full_path, recursive=False, follow_shortcuts=False):
                 )
             except NotFoundError:
                 print(
-                    "shortcut target not found!{}from shortcut: {}".format(
-                        "".rjust(65), shortcut
-                    )
+                    "Shortcut {} could not be resolved: "
+                    "the target may have been deleted or you may not have permission to access it".format(shortcut)
                 )
         else:
             resolved_file = file_

--- a/solvebio/cli/main.py
+++ b/solvebio/cli/main.py
@@ -288,6 +288,11 @@ class SolveArgumentParser(argparse.ArgumentParser):
                     "action": "store_true",
                 },
                 {
+                    "flags": "--follow-shortcuts",
+                    "help": "Resolves shortcuts when listing.",
+                    "action": "store_true",
+                },
+                {
                     "name": "full_path",
                     "help": "The full path where the files and folders should "
                     "be listed from, defaults to the root of your personal vault",


### PR DESCRIPTION
This pull request adds support for shortcuts when using the `ls` command.
The command would add `--follow-shortcuts` flag similar to `upload` and `download`