### PR TITLE
EDPDEV-1195 Handle Big Objects

### DIFF
--- a/solvebio/query.py
+++ b/solvebio/query.py
@@ -286,10 +286,16 @@ class QueryBase(object):
     def __repr__(self):
         # Check that Query/QueryFile object does not have any previous errors
         # otherwise, raise the error.
+        total_count = 0
+        try:
+            total_count = len(self)
+        except TypeError:
+            total_count = float("inf")
+
         if self._error:
             raise self._error
 
-        if len(self) == 0:
+        if total_count == 0:
             return 'Query returned 0 results.'
 
         placeholder = 'many more results (total unknown)'
@@ -303,13 +309,15 @@ class QueryBase(object):
             return '\n%s\n\n... %s more results.' % (
                 tabulate(list(self._buffer[0].items()), ['Fields', 'Data'],
                          aligns=['right', 'left'], sort=True),
-                pretty_int(len(self) - 1))
+                pretty_int(total_count - 1))
         else:
             is_tsv = self._output_format == 'tsv'
 
             # this is the only case when we know the exact number of total records
-            if len(self) < self._limit:
-                placeholder = '{} more results'.format(pretty_int(max(len(self) - 9, 0)))
+            if total_count < self._limit:
+                placeholder = '{} more results'.format(
+                    pretty_int(max(total_count - 9, 0))
+                )
 
             return '\n%s\n\n... %s.' % (
                 tabulate(list(enumerate(self._buffer[:10])), ['Row', 'Data'],
@@ -438,8 +446,12 @@ class QueryBase(object):
         _is_join = getattr(self, '_is_join', False)
 
         # len(self) returns `min(limit, total)` results
-        if not _is_join and self._cursor == len(self):
-            raise StopIteration
+        try:
+            if not _is_join and self._cursor == len(self):
+                raise StopIteration
+        except TypeError:
+            # len(self) is unknown so just continue normally
+            pass
 
         if self._buffer_idx == len(self._buffer):
             if _is_join:
@@ -1067,7 +1079,7 @@ class QueryFile(QueryBase):
             fields=None,
             exclude_fields=None,
             filters=None,
-            limit=QueryBase.INF,
+            limit=float('inf'),
             page_size=DEFAULT_PAGE_SIZE,
             output_format='json',
             header=True,
@@ -1220,3 +1232,13 @@ class QueryFile(QueryBase):
             fields = [f for f in fields if f not in self._exclude_fields]
 
         return fields
+
+    def __len__(self):
+        base_len = super(QueryFile, self).__len__()
+        if base_len == float('inf'):
+            raise TypeError(
+                'Unable to determine the number of records for the '
+                'current file-based query'
+            )
+        return base_len
+    

--- a/solvebio/test/helper.py
+++ b/solvebio/test/helper.py
@@ -17,6 +17,7 @@ class SolveBioTestCase(unittest.TestCase):
     TEST_DATASET_FULL_PATH = 'solvebio:public:/HGNC/3.3.0-2020-10-29/HGNC'
     TEST_DATASET_FULL_PATH_2 = 'solvebio:public:/ClinVar/5.1.0-20200720/Variants-GRCH38'
     TEST_FILE_FULL_PATH = 'solvebio:public:/HGNC/3.3.0-2020-10-29/hgnc_1000_rows.txt'
+    TEST_LARGE_TSV_FULL_PATH = ''
 
     def setUp(self):
         super(SolveBioTestCase, self).setUp()

--- a/solvebio/test/test_query.py
+++ b/solvebio/test/test_query.py
@@ -482,3 +482,17 @@ class BaseQueryTest(SolveBioTestCase):
             self.assertTrue('gene_symbol' in record)
             self.assertTrue('b_gene' in record)
             self.assertTrue('b_variant' in record)
+
+    def test_query_large_file_into_dataframe(self):
+        import pandas as pd
+        expected_num_rows = 1015
+
+        try:
+            large_object = self.client.Object.get_by_full_path(self.TEST_LARGE_TSV_FULL_PATH)
+            query = large_object.query()
+            dataframe = pd.DataFrame(query)
+        except Exception as e:
+            self.fail(f"Exception {e} was raised while querying large object")
+        self.assertTrue(not dataframe.empty)
+        self.assertEqual(expected_num_rows, len(dataframe))
+        


### PR DESCRIPTION
This PR handles big objects by handling len(self) differently and raising an error if the exact number of records is unkown.
Linked ticket:
https://precisionformedicine.atlassian.net/browse/EDPDEV-1195

Implementation details from ticket comments:

the [QueryFile](https://github.com/solvebio/solvebio-python/blob/master/solvebio/query.py#L1056) class currently sets the default _limit to INF which is a huge number. Instead of this, we can take a different approach which is to raise a TypeError from len() if we don’t know the true number of records

Many types of object “have no len” such as files and things, so this is technically a standard approach

The true max limit calculation happens in def __len__ which is not yet defined in the QueryFile subclass but we can define it there

Change QueryFile default _limit to be float('inf') same as for class Query for internal consistency

Subclass QueryFile.__len__ such that it attempts to determine the accurate length as it does now by considering _limit and total, but raises TypeError("Unable to determine the number of records") if self._limit == float('inf')… this is important because QueryFile.__len__ cannot return anything other than an integer.
Anywhere else in the class where len(self) is called, handle it a bit more carefully

in __repr__, if len(self) raises TypeError, assume the length is float('inf') and continue

in next(),  if len(self) raises TypeError, don’t raise StopIteration since we are not yet at the end