### PR TITLE
revert EDPDEV-1696 require SSL for all connections

### DIFF
--- a/solvebio/client.py
+++ b/solvebio/client.py
@@ -260,10 +260,6 @@ class SolveClient(object):
             'verify': True
         }
 
-        # For internal API endpoints, don't verify SSL certs
-        if self._host.endswith('.svc.cluster.local'):
-            opts['verify'] = False
-
         raw = kwargs.pop('raw', False)
         debug = kwargs.pop('debug', False)
         opts.update(kwargs)


### PR DESCRIPTION
Reverts 18139f9c225868cccf9447e53848bd308dbd15f4 as we no longer require this for internal connections